### PR TITLE
feat: themed message styles for the menu bar

### DIFF
--- a/Sources/ClaudeStatusBar/AppState.swift
+++ b/Sources/ClaudeStatusBar/AppState.swift
@@ -94,7 +94,8 @@ final class AppState {
         return MenuBarText.model(display: display, usage: activeUsage,
                                  style: displayStyle, showUsage: showUsageOnBar,
                                  yellowAt: yellowAt, redAt: redAt,
-                                 verb: currentVerb, now: Date())
+                                 verb: currentVerb, messageStyle: settings.messageStyle,
+                                 now: Date())
     }
 
     private func pollOnce() async {

--- a/Sources/ClaudeStatusBar/AppState.swift
+++ b/Sources/ClaudeStatusBar/AppState.swift
@@ -42,7 +42,7 @@ final class AppState {
         self.settings = settings ?? SettingsStore()
         self.usageStore = UsageStore(fetcher: UsageClient(), cacheFile: paths.usageCacheFile)
         self.currentVerb = ThinkingVerbs.all[0]
-        self.currentVerb = verbCycler.next(from: ThinkingVerbs.all)
+        self.currentVerb = verbCycler.next(from: self.settings.messageStyle.thinking)
     }
 
     func start() {
@@ -79,8 +79,16 @@ final class AppState {
         let previous = display?.state
         display = SessionAggregator.displayState(sessions)
         if display?.state == .thinking, previous != .thinking {
-            currentVerb = verbCycler.next(from: ThinkingVerbs.all)
+            currentVerb = verbCycler.next(from: settings.messageStyle.thinking)
         }
+    }
+
+    /// Called when the user picks a new message style: forget the no-repeat
+    /// memory (it indexes the old pool) and re-pick so a bar currently in
+    /// .thinking re-renders with the new style at once.
+    func rerollThinkingPhrase() {
+        verbCycler.reset()
+        currentVerb = verbCycler.next(from: settings.messageStyle.thinking)
     }
 
     func refreshUsageNow() async {

--- a/Sources/ClaudeStatusBar/AppState.swift
+++ b/Sources/ClaudeStatusBar/AppState.swift
@@ -42,7 +42,7 @@ final class AppState {
         self.settings = settings ?? SettingsStore()
         self.usageStore = UsageStore(fetcher: UsageClient(), cacheFile: paths.usageCacheFile)
         self.currentVerb = ThinkingVerbs.all[0]
-        self.currentVerb = verbCycler.next()
+        self.currentVerb = verbCycler.next(from: ThinkingVerbs.all)
     }
 
     func start() {
@@ -79,7 +79,7 @@ final class AppState {
         let previous = display?.state
         display = SessionAggregator.displayState(sessions)
         if display?.state == .thinking, previous != .thinking {
-            currentVerb = verbCycler.next()
+            currentVerb = verbCycler.next(from: ThinkingVerbs.all)
         }
     }
 

--- a/Sources/ClaudeStatusBar/SettingsView.swift
+++ b/Sources/ClaudeStatusBar/SettingsView.swift
@@ -8,7 +8,7 @@ struct SettingsView: View {
 
     var body: some View {
         TabView {
-            GeneralTab(settings: settings)
+            GeneralTab(appState: appState, settings: settings)
                 .tabItem { Label("General", systemImage: "gearshape") }
             ThresholdsTab(settings: settings)
                 .tabItem { Label("Thresholds", systemImage: "gauge") }
@@ -23,6 +23,7 @@ struct SettingsView: View {
 }
 
 private struct GeneralTab: View {
+    let appState: AppState
     @Bindable var settings: SettingsStore
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @State private var loginError: String?
@@ -45,6 +46,17 @@ private struct GeneralTab: View {
                 Text("Icon only").tag(DisplayStyle.iconOnly)
                 Text("Icon + %").tag(DisplayStyle.percent)
                 Text("Full").tag(DisplayStyle.full)
+            }
+            Picker("Message style", selection: $settings.messageStyleId) {
+                ForEach(MessageStyles.all) { style in
+                    Text(style.name).tag(style.id)
+                }
+            }
+            .onChange(of: settings.messageStyleId) {
+                // Instant feedback: a bar currently in .thinking re-renders
+                // now; tool/waiting text re-themes on the next TimelineView
+                // tick (≤1 s).
+                appState.rerollThinkingPhrase()
             }
             Picker("Usage poll interval", selection: $settings.pollMinutes) {
                 Text("1 min").tag(1)

--- a/Sources/StatusBarCore/Display/MenuBarText.swift
+++ b/Sources/StatusBarCore/Display/MenuBarText.swift
@@ -16,7 +16,8 @@ public enum MenuBarText {
     public static func model(display: SessionRecord?, usage: AccountUsageState?,
                              style: DisplayStyle, showUsage: Bool,
                              yellowAt: Double, redAt: Double,
-                             verb: String, now: Date) -> MenuBarLabelModel {
+                             verb: String, messageStyle: MessageStyle,
+                             now: Date) -> MenuBarLabelModel {
         let state = display?.state ?? .idle
 
         var activity: String?
@@ -25,11 +26,12 @@ public enum MenuBarText {
             switch display.state {
             case .tool:
                 let label = display.label ?? "Working"
-                activity = time.map { "\(label) · \($0)" } ?? label
+                let phrase = messageStyle.tool[label] ?? label
+                activity = time.map { "\(phrase) · \($0)" } ?? phrase
             case .thinking:
                 activity = time.map { "\(verb)… · \($0)" } ?? "\(verb)…"
             case .waiting:
-                activity = "Waiting for you"
+                activity = messageStyle.waiting
             case .idle:
                 activity = nil
             }

--- a/Sources/StatusBarCore/Display/MessageStyles.swift
+++ b/Sources/StatusBarCore/Display/MessageStyles.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// A themed set of menu bar phrases. `thinking` feeds `VerbCycler`;
+/// `tool` maps the hook's canonical labels (Editing, Running, Reading,
+/// Searching, Browsing, Delegating, Working) to themed phrases — unknown
+/// labels render unthemed via `tool[label] ?? label`; `waiting` replaces
+/// "Waiting for you". The popover keeps canonical text by design.
+public struct MessageStyle: Identifiable, Sendable {
+    public let id: String
+    public let name: String
+    public let thinking: [String]
+    public let tool: [String: String]
+    public let waiting: String
+}
+
+public enum MessageStyles {
+    public static let all: [MessageStyle] = [
+        classic, rpg, gardening, dumb, scifi, cooking, pirate,
+    ]
+
+    /// Total lookup: an id persisted by a future version (or corrupted)
+    /// must never crash the app — fall back to Classic, never write back.
+    public static func style(id: String) -> MessageStyle {
+        all.first { $0.id == id } ?? classic
+    }
+
+    static let classic = MessageStyle(
+        id: "classic", name: "Classic",
+        thinking: ThinkingVerbs.all,
+        tool: ["Editing": "Editing", "Running": "Running", "Reading": "Reading",
+               "Searching": "Searching", "Browsing": "Browsing",
+               "Delegating": "Delegating", "Working": "Working"],
+        waiting: "Waiting for you")
+
+    static let rpg = MessageStyle(
+        id: "rpg", name: "RPG",
+        thinking: ["Consulting the oracle", "Rolling for wisdom",
+                   "Studying ancient runes", "Brewing mana potions",
+                   "Sharpening the sword", "Reading the prophecy",
+                   "Charging the spell", "Plotting the quest",
+                   "Leveling up wisdom", "Taming wild ideas",
+                   "Gathering party buffs", "Deciphering old glyphs"],
+        tool: ["Editing": "Forging the blade", "Running": "Casting the spell",
+               "Reading": "Reading the scrolls", "Searching": "Scouting the dungeon",
+               "Browsing": "Charting distant lands", "Delegating": "Summoning the party",
+               "Working": "Grinding the XP"],
+        waiting: "Awaiting your command")
+
+    static let gardening = MessageStyle(
+        id: "gardening", name: "Gardening",
+        thinking: ["Watering the seedlings", "Sprouting new ideas",
+                   "Composting stray thoughts", "Sowing fresh seeds",
+                   "Sniffing the roses", "Grafting wild branches",
+                   "Mulching the beds", "Sunning the sprouts",
+                   "Repotting big ideas", "Trimming the hedges",
+                   "Feeding the roots", "Warming the greenhouse"],
+        tool: ["Editing": "Pruning the branches", "Running": "Turning the soil",
+               "Reading": "Reading seed packets", "Searching": "Hunting for weeds",
+               "Browsing": "Visiting the nursery", "Delegating": "Hiring garden gnomes",
+               "Working": "Tending the garden"],
+        waiting: "Ripe for picking")
+
+    static let dumb = MessageStyle(
+        id: "dumb", name: "Dumb",
+        thinking: ["Making think happen", "Doing brain stuff",
+                   "Vibing real hard", "Loading smart thoughts",
+                   "Buffering big brain", "Thinking really hard",
+                   "Consulting inner monologue", "Staring at ceiling",
+                   "Rebooting the noggin", "Doing a ponder",
+                   "Cooking hot takes", "Charging brain cells"],
+        tool: ["Editing": "Typing many words", "Running": "Pressing big button",
+               "Reading": "Looking at stuff", "Searching": "Finding the thing",
+               "Browsing": "Surfing the webs", "Delegating": "Making friends work",
+               "Working": "Doing the thing"],
+        waiting: "Your turn buddy")
+
+    static let scifi = MessageStyle(
+        id: "scifi", name: "Sci-Fi",
+        thinking: ["Computing warp trajectories", "Consulting ship AI",
+                   "Calibrating the sensors", "Charging photon banks",
+                   "Mapping wormhole routes", "Decoding alien signals",
+                   "Aligning the antenna", "Simulating first contact",
+                   "Cooling the reactor", "Plotting orbital burns",
+                   "Syncing quantum clocks", "Scanning nebula clouds"],
+        tool: ["Editing": "Rewiring the core", "Running": "Firing the thrusters",
+               "Reading": "Scanning data banks", "Searching": "Probing deep space",
+               "Browsing": "Hailing distant stations", "Delegating": "Deploying drone fleet",
+               "Working": "Running ship diagnostics"],
+        waiting: "Awaiting your orders")
+
+    static let cooking = MessageStyle(
+        id: "cooking", name: "Cooking",
+        thinking: ["Tasting the broth", "Whisking fresh ideas",
+                   "Reducing the sauce", "Proofing the dough",
+                   "Caramelizing the onions", "Seasoning to taste",
+                   "Simmering the stock", "Kneading raw thoughts",
+                   "Toasting the spices", "Resting the roast",
+                   "Glazing the tart", "Julienning the details"],
+        tool: ["Editing": "Plating the dish", "Running": "Firing the stove",
+               "Reading": "Reading the recipe", "Searching": "Raiding the pantry",
+               "Browsing": "Shopping the market", "Delegating": "Calling sous chefs",
+               "Working": "Prepping the ingredients"],
+        waiting: "Order up, chef")
+
+    static let pirate = MessageStyle(
+        id: "pirate", name: "Pirate",
+        thinking: ["Plotting the course", "Reading the stars",
+                   "Studying the charts", "Counting gold doubloons",
+                   "Eyeing the horizon", "Trimming the mainsail",
+                   "Whispering to parrots", "Sniffing for treasure",
+                   "Tying sailor knots", "Weathering the storm",
+                   "Charting hidden coves", "Polishing the spyglass"],
+        tool: ["Editing": "Patching the sails", "Running": "Firing the cannons",
+               "Reading": "Studying the map", "Searching": "Digging for treasure",
+               "Browsing": "Scanning the horizon", "Delegating": "Rallying the crew",
+               "Working": "Swabbing the deck"],
+        waiting: "Cap'n needs orders")
+}

--- a/Sources/StatusBarCore/Display/ThinkingVerbs.swift
+++ b/Sources/StatusBarCore/Display/ThinkingVerbs.swift
@@ -10,7 +10,10 @@ public enum ThinkingVerbs {
     ]
 }
 
-/// Uniform random verb picker that never repeats the previous verb.
+/// Uniform random phrase picker that never repeats the previous pick.
+/// Pool-agnostic: the caller passes the pool each draw, so switching
+/// message styles mid-flight is safe. Precondition: `phrases` is non-empty
+/// (guaranteed by the MessageStyles catalog invariant tests).
 public struct VerbCycler {
     let rng: () -> Double
     var previousIndex: Int?
@@ -19,13 +22,21 @@ public struct VerbCycler {
         self.rng = rng
     }
 
-    public mutating func next() -> String {
-        let verbs = ThinkingVerbs.all
+    public mutating func next(from phrases: [String]) -> String {
+        // A remembered index may come from a different (larger) pool; and in
+        // a one-phrase pool the no-repeat rule is unsatisfiable. Forget it.
+        if let previous = previousIndex, previous >= phrases.count || phrases.count == 1 {
+            previousIndex = nil
+        }
         // Draw from the pool minus the previous pick, then map back to full indices.
-        let poolSize = previousIndex == nil ? verbs.count : verbs.count - 1
+        let poolSize = previousIndex == nil ? phrases.count : phrases.count - 1
         var index = min(Int(rng() * Double(poolSize)), poolSize - 1)
         if let previous = previousIndex, index >= previous { index += 1 }
         previousIndex = index
-        return verbs[index]
+        return phrases[index]
+    }
+
+    public mutating func reset() {
+        previousIndex = nil
     }
 }

--- a/Sources/StatusBarCore/Settings/SettingsStore.swift
+++ b/Sources/StatusBarCore/Settings/SettingsStore.swift
@@ -25,10 +25,19 @@ public final class SettingsStore {
     public var hiddenAccounts: [String] {
         didSet { defaults.set(hiddenAccounts, forKey: "hiddenAccounts") }
     }
+    public var messageStyleId: String {
+        didSet { defaults.set(messageStyleId, forKey: "messageStyleId") }
+    }
 
     public var displayStyle: DisplayStyle {
         get { DisplayStyle(rawValue: displayStyleRaw) ?? .full }
         set { displayStyleRaw = newValue.rawValue }
+    }
+
+    /// Total: an unknown persisted id falls back to Classic (never crashes,
+    /// never writes the fallback back to defaults).
+    public var messageStyle: MessageStyle {
+        MessageStyles.style(id: messageStyleId)
     }
 
     public init(defaults: UserDefaults = .standard) {
@@ -39,5 +48,6 @@ public final class SettingsStore {
         yellowAt = defaults.object(forKey: "yellowAt") as? Double ?? 50
         redAt = defaults.object(forKey: "redAt") as? Double ?? 80
         hiddenAccounts = defaults.stringArray(forKey: "hiddenAccounts") ?? []
+        messageStyleId = defaults.string(forKey: "messageStyleId") ?? "classic"
     }
 }

--- a/Tests/StatusBarCoreTests/MenuBarTextTests.swift
+++ b/Tests/StatusBarCoreTests/MenuBarTextTests.swift
@@ -87,17 +87,42 @@ private func usage(five: Double, seven: Double) -> AccountUsageState {
     @Test func neverRepeatsImmediately() {
         // rng always returns 0 -> would always pick index 0 without the no-repeat rule
         var cycler = VerbCycler(rng: { 0 })
-        let first = cycler.next()
-        let second = cycler.next()
+        let first = cycler.next(from: ThinkingVerbs.all)
+        let second = cycler.next(from: ThinkingVerbs.all)
         #expect(first != second)
 
         var random = VerbCycler()
-        var previous = random.next()
+        var previous = random.next(from: ThinkingVerbs.all)
         for _ in 0..<200 {
-            let verb = random.next()
+            let verb = random.next(from: ThinkingVerbs.all)
             #expect(verb != previous)
             #expect(ThinkingVerbs.all.contains(verb))
             previous = verb
         }
+    }
+
+    @Test func stalePreviousIndexIsForgottenOnSmallerPool() {
+        // rng 0.99 picks the last index: 4 in the big pool — out of range for
+        // the small pool. Must be treated as nil, never index out of bounds.
+        var cycler = VerbCycler(rng: { 0.99 })
+        let big = ["a", "b", "c", "d", "e"]
+        #expect(cycler.next(from: big) == "e")
+        let small = ["x", "y"]
+        let pick = cycler.next(from: small)
+        #expect(small.contains(pick))
+    }
+
+    @Test func singlePhrasePoolRepeatsWithoutCrashing() {
+        var cycler = VerbCycler(rng: { 0 })
+        #expect(cycler.next(from: ["only"]) == "only")
+        #expect(cycler.next(from: ["only"]) == "only")
+    }
+
+    @Test func resetClearsNoRepeatMemory() {
+        // rng 0 always picks index 0; after reset() the same phrase may repeat.
+        var cycler = VerbCycler(rng: { 0 })
+        let first = cycler.next(from: ThinkingVerbs.all)
+        cycler.reset()
+        #expect(cycler.next(from: ThinkingVerbs.all) == first)
     }
 }

--- a/Tests/StatusBarCoreTests/MenuBarTextTests.swift
+++ b/Tests/StatusBarCoreTests/MenuBarTextTests.swift
@@ -30,10 +30,12 @@ private func usage(five: Double, seven: Double) -> AccountUsageState {
 
 @Suite struct MenuBarTextTests {
     private func model(display: SessionRecord?, usage: AccountUsageState?,
-                       style: DisplayStyle, showUsage: Bool = true) -> MenuBarLabelModel {
+                       style: DisplayStyle, showUsage: Bool = true,
+                       messageStyle: MessageStyle = MessageStyles.style(id: "classic"))
+        -> MenuBarLabelModel {
         MenuBarText.model(display: display, usage: usage, style: style,
                           showUsage: showUsage, yellowAt: 50, redAt: 80,
-                          verb: "Pondering", now: now)
+                          verb: "Pondering", messageStyle: messageStyle, now: now)
     }
 
     @Test func toolStateShowsLabelAndElapsed() {
@@ -75,6 +77,44 @@ private func usage(five: Double, seven: Double) -> AccountUsageState {
         #expect(m.fiveHourLevel == .red)
         #expect(m.sevenDayLevel == .yellow)
         #expect(model(display: nil, usage: nil, style: .full).fiveHourLevel == nil)
+    }
+
+    @Test func toolLabelThemedByStyle() {
+        let m = model(display: session(.tool, label: "Editing", busyFor: 192),
+                      usage: nil, style: .full,
+                      messageStyle: MessageStyles.style(id: "rpg"))
+        #expect(m.activityText == "Forging the blade · 3m 12s")
+    }
+
+    @Test func unknownToolLabelPassesThroughUnthemed() {
+        // Capitalized raw tool names from the hook fallback (e.g. WebFetch)
+        // are not in any style's map — they render as-is.
+        let m = model(display: session(.tool, label: "WebFetch", busyFor: 45),
+                      usage: nil, style: .full,
+                      messageStyle: MessageStyles.style(id: "pirate"))
+        #expect(m.activityText == "WebFetch · 45s")
+    }
+
+    @Test func missingLabelThemedAsWorking() {
+        let m = model(display: session(.tool, busyFor: 45), usage: nil, style: .full,
+                      messageStyle: MessageStyles.style(id: "scifi"))
+        #expect(m.activityText == "Running ship diagnostics · 45s")
+    }
+
+    @Test func waitingUsesStylePhrase() {
+        let m = model(display: session(.waiting, busyFor: 45), usage: nil, style: .full,
+                      messageStyle: MessageStyles.style(id: "cooking"))
+        #expect(m.activityText == "Order up, chef")
+    }
+
+    @Test func classicRendersByteIdenticalToV1() {
+        let tool = model(display: session(.tool, label: "Editing", busyFor: 12),
+                         usage: nil, style: .full)
+        #expect(tool.activityText == "Editing · 12s")
+        let waiting = model(display: session(.waiting, busyFor: 12), usage: nil, style: .full)
+        #expect(waiting.activityText == "Waiting for you")
+        let thinking = model(display: session(.thinking, busyFor: 12), usage: nil, style: .full)
+        #expect(thinking.activityText == "Pondering… · 12s")
     }
 }
 

--- a/Tests/StatusBarCoreTests/MessageStylesTests.swift
+++ b/Tests/StatusBarCoreTests/MessageStylesTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import StatusBarCore
+
+private let canonicalLabels = ["Editing", "Running", "Reading", "Searching",
+                               "Browsing", "Delegating", "Working"]
+
+private func wordCount(_ phrase: String) -> Int {
+    phrase.split(whereSeparator: \.isWhitespace).count
+}
+
+@Suite struct MessageStyleCatalogTests {
+    @Test func lineupIsSevenStylesClassicFirst() {
+        #expect(MessageStyles.all.map(\.id)
+                == ["classic", "rpg", "gardening", "dumb", "scifi", "cooking", "pirate"])
+    }
+
+    @Test func idsAreUnique() {
+        #expect(Set(MessageStyles.all.map(\.id)).count == MessageStyles.all.count)
+    }
+
+    @Test func everyStyleCoversAllCanonicalLabels() {
+        for style in MessageStyles.all {
+            #expect(Set(style.tool.keys) == Set(canonicalLabels), "\(style.id)")
+            #expect(!style.thinking.isEmpty, "\(style.id)")
+            #expect(!style.waiting.isEmpty, "\(style.id)")
+        }
+    }
+
+    @Test func themedThinkingPoolsHaveTwelveUniquePhrases() {
+        for style in MessageStyles.all where style.id != "classic" {
+            #expect(style.thinking.count == 12, "\(style.id)")
+            #expect(Set(style.thinking).count == 12, "\(style.id)")
+        }
+    }
+
+    @Test func themedPhrasesAreThreeToFourWords() {
+        for style in MessageStyles.all where style.id != "classic" {
+            for phrase in style.thinking {
+                #expect((3...4).contains(wordCount(phrase)), "\(style.id): \(phrase)")
+            }
+            for phrase in style.tool.values {
+                #expect((3...4).contains(wordCount(phrase)), "\(style.id): \(phrase)")
+            }
+            #expect((3...4).contains(wordCount(style.waiting)), "\(style.id): \(style.waiting)")
+        }
+    }
+
+    @Test func classicPreservesTodayExactly() {
+        let classic = MessageStyles.style(id: "classic")
+        #expect(classic.thinking == ThinkingVerbs.all)
+        for label in canonicalLabels {
+            #expect(classic.tool[label] == label)
+        }
+        #expect(classic.waiting == "Waiting for you")
+    }
+
+    @Test func unknownIdFallsBackToClassic() {
+        #expect(MessageStyles.style(id: "nope").id == "classic")
+        #expect(MessageStyles.style(id: "").id == "classic")
+        #expect(MessageStyles.style(id: "pirate").id == "pirate")
+    }
+}

--- a/Tests/StatusBarCoreTests/SettingsStoreTests.swift
+++ b/Tests/StatusBarCoreTests/SettingsStoreTests.swift
@@ -44,6 +44,31 @@ import Testing
         defaults.set("hologram", forKey: "displayStyleRaw")
         #expect(SettingsStore(defaults: defaults).displayStyle == .full)
     }
+
+    @Test func messageStyleDefaultsToClassic() {
+        let store = SettingsStore(defaults: makeDefaults())
+        #expect(store.messageStyleId == "classic")
+        #expect(store.messageStyle.id == "classic")
+    }
+
+    @Test func messageStyleIdPersistsAcrossInstances() {
+        let defaults = makeDefaults()
+        let store = SettingsStore(defaults: defaults)
+        store.messageStyleId = "pirate"
+        let reloaded = SettingsStore(defaults: defaults)
+        #expect(reloaded.messageStyleId == "pirate")
+        #expect(reloaded.messageStyle.id == "pirate")
+    }
+
+    @Test func unknownMessageStyleIdResolvesToClassicWithoutWriteBack() {
+        let defaults = makeDefaults()
+        defaults.set("vaporwave", forKey: "messageStyleId")
+        let store = SettingsStore(defaults: defaults)
+        #expect(store.messageStyle.id == "classic")
+        // The raw value is preserved — never rewritten to "classic".
+        #expect(store.messageStyleId == "vaporwave")
+        #expect(defaults.string(forKey: "messageStyleId") == "vaporwave")
+    }
 }
 
 @Suite struct HookLocatorTests {

--- a/docs/superpowers/plans/2026-07-11-message-styles.md
+++ b/docs/superpowers/plans/2026-07-11-message-styles.md
@@ -1,0 +1,761 @@
+# Message Styles Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user pick a themed "message style" (Classic + 6 themes) that rewrites the menu bar's thinking/tool/waiting text, via a picker in Settings → General.
+
+**Architecture:** Display-time theming. A new `MessageStyles` catalog in StatusBarCore maps canonical activity labels (baked into session files by the hook) to themed phrases at render time. `VerbCycler` generalizes to draw from any phrase pool, `MenuBarText.model` gains a `messageStyle` parameter, `SettingsStore` persists the chosen style id, and `AppState` re-rolls the thinking phrase on style switch. Hook binary, session-file format, popover (`SessionsSection`), and `StatusIcon` are untouched.
+
+**Tech Stack:** Swift 6.0 toolchain in `.swiftLanguageMode(.v5)`, SwiftPM (no Xcode — CLT-only machine), macOS 14+, swift-testing pinned `exact: "0.12.0"`.
+
+**Spec:** `docs/superpowers/specs/2026-07-11-message-styles-design.md` (commit `1075e8b`). One deliberate deviation: the spec names the new `MenuBarText.model` parameter `style:`, but that label already belongs to the existing `style: DisplayStyle` parameter — this plan names it `messageStyle:` instead.
+
+## Global Constraints
+
+- swift-testing is pinned `exact: "0.12.0"` — use ONLY `@Test`, `@Suite`, `#expect`, `#require`. No other swift-testing API (no traits, no parameterized `arguments:`, no `withKnownIssue`).
+- Clean-room: every themed phrase is original and appears verbatim in this plan. Never copy code, strings, or verbs from vntrungld/claude-status-bar-kde or any other status-bar project.
+- Every themed phrase (thinking, tool, waiting — all styles except `classic`) is exactly 3–4 whitespace-separated words. Transcribe phrases from this plan byte-exactly; do not "improve" them.
+- Classic is the default style and must render byte-identically to v1: verbs from `ThinkingVerbs.all`, tool text `Editing · 12s`, waiting text `Waiting for you`.
+- Untouched files/behavior: hook binary (`Sources/ClaudeStatusHook/`), `SessionReducer`, session-file format, `SessionsSection.swift` (popover keeps canonical text), `StatusIcon`.
+- All code, comments, tests, and commit messages in English. Commit subjects imperative, ≤72 chars.
+- Work on branch `feat/message-styles` (exists; base `main` @ `5db72a4`). Never push to main/master, never force-push.
+- Test command: `swift test` from the repo root `/Users/ser/scatola/jobs/projects/claude-status-bar-macos`. Full suite (77 tests pre-existing) must pass at the end of every task.
+- The shell's working directory may reset between commands — prefix every command with `cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && `.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `Sources/StatusBarCore/Display/MessageStyles.swift` | **Create** (Task 1) | `MessageStyle` struct + the 7-style catalog + total `style(id:)` lookup |
+| `Tests/StatusBarCoreTests/MessageStylesTests.swift` | **Create** (Task 1) | Catalog invariants + registry fallback tests |
+| `Sources/StatusBarCore/Display/ThinkingVerbs.swift` | Modify (Task 2) | `VerbCycler.next(from:)` + `reset()`; `ThinkingVerbs.all` unchanged |
+| `Sources/StatusBarCore/Settings/SettingsStore.swift` | Modify (Task 3) | Persisted `messageStyleId` + computed `messageStyle` |
+| `Tests/StatusBarCoreTests/SettingsStoreTests.swift` | Modify (Task 3) | Persistence + fallback tests |
+| `Sources/StatusBarCore/Display/MenuBarText.swift` | Modify (Task 4) | `messageStyle` parameter; themed `.tool`/`.waiting` text |
+| `Tests/StatusBarCoreTests/MenuBarTextTests.swift` | Modify (Tasks 2, 4) | Cycler tests for new signature; theming + regression tests |
+| `Sources/ClaudeStatusBar/AppState.swift` | Modify (Tasks 2, 4, 5) | Draw verbs from active style pool; `rerollThinkingPhrase()` |
+| `Sources/ClaudeStatusBar/SettingsView.swift` | Modify (Task 6) | "Message style" picker in GeneralTab |
+
+Note: `Sources/ClaudeStatusBar/` is the executable target — SwiftPM test targets cannot import it, so AppState/SettingsView changes are verified by `swift build` + the full core suite, not by new unit tests (same as v1).
+
+---
+
+### Task 1: MessageStyles catalog
+
+**Files:**
+- Create: `Sources/StatusBarCore/Display/MessageStyles.swift`
+- Test: `Tests/StatusBarCoreTests/MessageStylesTests.swift` (create)
+
+**Interfaces:**
+- Consumes: `ThinkingVerbs.all` (existing `[String]`, 28 verbs).
+- Produces: `public struct MessageStyle: Identifiable, Sendable { let id, name: String; let thinking: [String]; let tool: [String: String]; let waiting: String }`; `public enum MessageStyles { static let all: [MessageStyle]; static func style(id: String) -> MessageStyle }`. Later tasks rely on: `MessageStyles.style(id:)` being total (unknown id → classic), `all` ordered classic-first, and `tool` maps covering exactly the 7 canonical labels `Editing`, `Running`, `Reading`, `Searching`, `Browsing`, `Delegating`, `Working`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/StatusBarCoreTests/MessageStylesTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import StatusBarCore
+
+private let canonicalLabels = ["Editing", "Running", "Reading", "Searching",
+                               "Browsing", "Delegating", "Working"]
+
+private func wordCount(_ phrase: String) -> Int {
+    phrase.split(whereSeparator: \.isWhitespace).count
+}
+
+@Suite struct MessageStyleCatalogTests {
+    @Test func lineupIsSevenStylesClassicFirst() {
+        #expect(MessageStyles.all.map(\.id)
+                == ["classic", "rpg", "gardening", "dumb", "scifi", "cooking", "pirate"])
+    }
+
+    @Test func idsAreUnique() {
+        #expect(Set(MessageStyles.all.map(\.id)).count == MessageStyles.all.count)
+    }
+
+    @Test func everyStyleCoversAllCanonicalLabels() {
+        for style in MessageStyles.all {
+            #expect(Set(style.tool.keys) == Set(canonicalLabels), "\(style.id)")
+            #expect(!style.thinking.isEmpty, "\(style.id)")
+            #expect(!style.waiting.isEmpty, "\(style.id)")
+        }
+    }
+
+    @Test func themedThinkingPoolsHaveTwelveUniquePhrases() {
+        for style in MessageStyles.all where style.id != "classic" {
+            #expect(style.thinking.count == 12, "\(style.id)")
+            #expect(Set(style.thinking).count == 12, "\(style.id)")
+        }
+    }
+
+    @Test func themedPhrasesAreThreeToFourWords() {
+        for style in MessageStyles.all where style.id != "classic" {
+            for phrase in style.thinking {
+                #expect((3...4).contains(wordCount(phrase)), "\(style.id): \(phrase)")
+            }
+            for phrase in style.tool.values {
+                #expect((3...4).contains(wordCount(phrase)), "\(style.id): \(phrase)")
+            }
+            #expect((3...4).contains(wordCount(style.waiting)), "\(style.id): \(style.waiting)")
+        }
+    }
+
+    @Test func classicPreservesTodayExactly() {
+        let classic = MessageStyles.style(id: "classic")
+        #expect(classic.thinking == ThinkingVerbs.all)
+        for label in canonicalLabels {
+            #expect(classic.tool[label] == label)
+        }
+        #expect(classic.waiting == "Waiting for you")
+    }
+
+    @Test func unknownIdFallsBackToClassic() {
+        #expect(MessageStyles.style(id: "nope").id == "classic")
+        #expect(MessageStyles.style(id: "").id == "classic")
+        #expect(MessageStyles.style(id: "pirate").id == "pirate")
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && swift test --filter MessageStyleCatalogTests`
+Expected: BUILD FAILURE — `cannot find 'MessageStyles' in scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/StatusBarCore/Display/MessageStyles.swift`:
+
+```swift
+import Foundation
+
+/// A themed set of menu bar phrases. `thinking` feeds `VerbCycler`;
+/// `tool` maps the hook's canonical labels (Editing, Running, Reading,
+/// Searching, Browsing, Delegating, Working) to themed phrases — unknown
+/// labels render unthemed via `tool[label] ?? label`; `waiting` replaces
+/// "Waiting for you". The popover keeps canonical text by design.
+public struct MessageStyle: Identifiable, Sendable {
+    public let id: String
+    public let name: String
+    public let thinking: [String]
+    public let tool: [String: String]
+    public let waiting: String
+}
+
+public enum MessageStyles {
+    public static let all: [MessageStyle] = [
+        classic, rpg, gardening, dumb, scifi, cooking, pirate,
+    ]
+
+    /// Total lookup: an id persisted by a future version (or corrupted)
+    /// must never crash the app — fall back to Classic, never write back.
+    public static func style(id: String) -> MessageStyle {
+        all.first { $0.id == id } ?? classic
+    }
+
+    static let classic = MessageStyle(
+        id: "classic", name: "Classic",
+        thinking: ThinkingVerbs.all,
+        tool: ["Editing": "Editing", "Running": "Running", "Reading": "Reading",
+               "Searching": "Searching", "Browsing": "Browsing",
+               "Delegating": "Delegating", "Working": "Working"],
+        waiting: "Waiting for you")
+
+    static let rpg = MessageStyle(
+        id: "rpg", name: "RPG",
+        thinking: ["Consulting the oracle", "Rolling for wisdom",
+                   "Studying ancient runes", "Brewing mana potions",
+                   "Sharpening the sword", "Reading the prophecy",
+                   "Charging the spell", "Plotting the quest",
+                   "Leveling up wisdom", "Taming wild ideas",
+                   "Gathering party buffs", "Deciphering old glyphs"],
+        tool: ["Editing": "Forging the blade", "Running": "Casting the spell",
+               "Reading": "Reading the scrolls", "Searching": "Scouting the dungeon",
+               "Browsing": "Charting distant lands", "Delegating": "Summoning the party",
+               "Working": "Grinding the XP"],
+        waiting: "Awaiting your command")
+
+    static let gardening = MessageStyle(
+        id: "gardening", name: "Gardening",
+        thinking: ["Watering the seedlings", "Sprouting new ideas",
+                   "Composting stray thoughts", "Sowing fresh seeds",
+                   "Sniffing the roses", "Grafting wild branches",
+                   "Mulching the beds", "Sunning the sprouts",
+                   "Repotting big ideas", "Trimming the hedges",
+                   "Feeding the roots", "Warming the greenhouse"],
+        tool: ["Editing": "Pruning the branches", "Running": "Turning the soil",
+               "Reading": "Reading seed packets", "Searching": "Hunting for weeds",
+               "Browsing": "Visiting the nursery", "Delegating": "Hiring garden gnomes",
+               "Working": "Tending the garden"],
+        waiting: "Ripe for picking")
+
+    static let dumb = MessageStyle(
+        id: "dumb", name: "Dumb",
+        thinking: ["Making think happen", "Doing brain stuff",
+                   "Vibing real hard", "Loading smart thoughts",
+                   "Buffering big brain", "Thinking really hard",
+                   "Consulting inner monologue", "Staring at ceiling",
+                   "Rebooting the noggin", "Doing a ponder",
+                   "Cooking hot takes", "Charging brain cells"],
+        tool: ["Editing": "Typing many words", "Running": "Pressing big button",
+               "Reading": "Looking at stuff", "Searching": "Finding the thing",
+               "Browsing": "Surfing the webs", "Delegating": "Making friends work",
+               "Working": "Doing the thing"],
+        waiting: "Your turn buddy")
+
+    static let scifi = MessageStyle(
+        id: "scifi", name: "Sci-Fi",
+        thinking: ["Computing warp trajectories", "Consulting ship AI",
+                   "Calibrating the sensors", "Charging photon banks",
+                   "Mapping wormhole routes", "Decoding alien signals",
+                   "Aligning the antenna", "Simulating first contact",
+                   "Cooling the reactor", "Plotting orbital burns",
+                   "Syncing quantum clocks", "Scanning nebula clouds"],
+        tool: ["Editing": "Rewiring the core", "Running": "Firing the thrusters",
+               "Reading": "Scanning data banks", "Searching": "Probing deep space",
+               "Browsing": "Hailing distant stations", "Delegating": "Deploying drone fleet",
+               "Working": "Running ship diagnostics"],
+        waiting: "Awaiting your orders")
+
+    static let cooking = MessageStyle(
+        id: "cooking", name: "Cooking",
+        thinking: ["Tasting the broth", "Whisking fresh ideas",
+                   "Reducing the sauce", "Proofing the dough",
+                   "Caramelizing the onions", "Seasoning to taste",
+                   "Simmering the stock", "Kneading raw thoughts",
+                   "Toasting the spices", "Resting the roast",
+                   "Glazing the tart", "Julienning the details"],
+        tool: ["Editing": "Plating the dish", "Running": "Firing the stove",
+               "Reading": "Reading the recipe", "Searching": "Raiding the pantry",
+               "Browsing": "Shopping the market", "Delegating": "Calling sous chefs",
+               "Working": "Prepping the ingredients"],
+        waiting: "Order up, chef")
+
+    static let pirate = MessageStyle(
+        id: "pirate", name: "Pirate",
+        thinking: ["Plotting the course", "Reading the stars",
+                   "Studying the charts", "Counting gold doubloons",
+                   "Eyeing the horizon", "Trimming the mainsail",
+                   "Whispering to parrots", "Sniffing for treasure",
+                   "Tying sailor knots", "Weathering the storm",
+                   "Charting hidden coves", "Polishing the spyglass"],
+        tool: ["Editing": "Patching the sails", "Running": "Firing the cannons",
+               "Reading": "Studying the map", "Searching": "Digging for treasure",
+               "Browsing": "Scanning the horizon", "Delegating": "Rallying the crew",
+               "Working": "Swabbing the deck"],
+        waiting: "Cap'n needs orders")
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && swift test --filter MessageStyleCatalogTests`
+Expected: PASS — 7 tests.
+
+Then run the full suite: `cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && swift test`
+Expected: PASS — 84 tests (77 existing + 7 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && git add Sources/StatusBarCore/Display/MessageStyles.swift Tests/StatusBarCoreTests/MessageStylesTests.swift && git commit -m "feat: add MessageStyles catalog (7 themed phrase sets)"
+```
+
+---
+
+### Task 2: Generalize VerbCycler to arbitrary phrase pools
+
+**Files:**
+- Modify: `Sources/StatusBarCore/Display/ThinkingVerbs.swift:13-31` (the `VerbCycler` struct)
+- Modify: `Sources/ClaudeStatusBar/AppState.swift:45,82` (call sites — keep the package compiling)
+- Test: `Tests/StatusBarCoreTests/MenuBarTextTests.swift` (the `ThinkingVerbsTests` suite)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `VerbCycler.next(from phrases: [String]) -> String` (mutating) and `VerbCycler.reset()` (mutating). The no-argument `next()` is REMOVED. `ThinkingVerbs.all` stays exactly as-is (public API, referenced by tests and the classic style). Task 5 relies on `next(from:)` + `reset()` with these exact names.
+
+- [ ] **Step 1: Update existing tests and write the new failing tests**
+
+In `Tests/StatusBarCoreTests/MenuBarTextTests.swift`, replace the entire `ThinkingVerbsTests` suite (currently the last suite in the file, lines 81–103) with:
+
+```swift
+@Suite struct ThinkingVerbsTests {
+    @Test func has28UniqueVerbs() {
+        #expect(ThinkingVerbs.all.count == 28)
+        #expect(Set(ThinkingVerbs.all).count == 28)
+    }
+
+    @Test func neverRepeatsImmediately() {
+        // rng always returns 0 -> would always pick index 0 without the no-repeat rule
+        var cycler = VerbCycler(rng: { 0 })
+        let first = cycler.next(from: ThinkingVerbs.all)
+        let second = cycler.next(from: ThinkingVerbs.all)
+        #expect(first != second)
+
+        var random = VerbCycler()
+        var previous = random.next(from: ThinkingVerbs.all)
+        for _ in 0..<200 {
+            let verb = random.next(from: ThinkingVerbs.all)
+            #expect(verb != previous)
+            #expect(ThinkingVerbs.all.contains(verb))
+            previous = verb
+        }
+    }
+
+    @Test func stalePreviousIndexIsForgottenOnSmallerPool() {
+        // rng 0.99 picks the last index: 4 in the big pool — out of range for
+        // the small pool. Must be treated as nil, never index out of bounds.
+        var cycler = VerbCycler(rng: { 0.99 })
+        let big = ["a", "b", "c", "d", "e"]
+        #expect(cycler.next(from: big) == "e")
+        let small = ["x", "y"]
+        let pick = cycler.next(from: small)
+        #expect(small.contains(pick))
+    }
+
+    @Test func singlePhrasePoolRepeatsWithoutCrashing() {
+        var cycler = VerbCycler(rng: { 0 })
+        #expect(cycler.next(from: ["only"]) == "only")
+        #expect(cycler.next(from: ["only"]) == "only")
+    }
+
+    @Test func resetClearsNoRepeatMemory() {
+        // rng 0 always picks index 0; after reset() the same phrase may repeat.
+        var cycler = VerbCycler(rng: { 0 })
+        let first = cycler.next(from: ThinkingVerbs.all)
+        cycler.reset()
+        #expect(cycler.next(from: ThinkingVerbs.all) == first)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && swift test --filter ThinkingVerbsTests`
+Expected: BUILD FAILURE — `extra argument 'from' in call` / `cannot find 'reset'` (the new signature doesn't exist yet).
+
+- [ ] **Step 3: Write the implementation**
+
+In `Sources/StatusBarCore/Display/ThinkingVerbs.swift`, replace the `VerbCycler` struct (keep `ThinkingVerbs` above it untouched):
+
+```swift
+/// Uniform random phrase picker that never repeats the previous pick.
+/// Pool-agnostic: the caller passes the pool each draw, so switching
+/// message styles mid-flight is safe. Precondition: `phrases` is non-empty
+/// (guaranteed by the MessageStyles catalog invariant tests).
+public struct VerbCycler {
+    let rng: () -> Double
+    var previousIndex: Int?
+
+    public init(rng: @escaping () -> Double = { Double.random(in: 0..<1) }) {
+        self.rng = rng
+    }
+
+    public mutating func next(from phrases: [String]) -> String {
+        // A remembered index may come from a different (larger) pool; and in
+        // a one-phrase pool the no-repeat rule is unsatisfiable. Forget it.
+        if let previous = previousIndex, previous >= phrases.count || phrases.count == 1 {
+            previousIndex = nil
+        }
+        // Draw from the pool minus the previous pick, then map back to full indices.
+        let poolSize = previousIndex == nil ? phrases.count : phrases.count - 1
+        var index = min(Int(rng() * Double(poolSize)), poolSize - 1)
+        if let previous = previousIndex, index >= previous { index += 1 }
+        previousIndex = index
+        return phrases[index]
+    }
+
+    public mutating func reset() {
+        previousIndex = nil
+    }
+}
+```
+
+In `Sources/ClaudeStatusBar/AppState.swift`, update the two call sites so the executable target keeps compiling (still drawing from the classic pool — Task 5 switches this to the active style's pool):
+
+Line 45 — change:
+```swift
+        self.currentVerb = verbCycler.next()
+```
+to:
+```swift
+        self.currentVerb = verbCycler.next(from: ThinkingVerbs.all)
+```
+
+Line 82 (inside `reaggregate()`) — change:
+```swift
+            currentVerb = verbCycler.next()
+```
+to:
+```swift
+            currentVerb = verbCycler.next(from: ThinkingVerbs.all)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && swift test`
+Expected: PASS — 87 tests (84 + 3 new cycler tests). `swift build` must also succeed (AppState call sites updated).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && git add Sources/StatusBarCore/Display/ThinkingVerbs.swift Sources/ClaudeStatusBar/AppState.swift Tests/StatusBarCoreTests/MenuBarTextTests.swift && git commit -m "feat: generalize VerbCycler to arbitrary phrase pools"
+```
+
+---
+
+### Task 3: Persist message style choice in SettingsStore
+
+**Files:**
+- Modify: `Sources/StatusBarCore/Settings/SettingsStore.swift`
+- Test: `Tests/StatusBarCoreTests/SettingsStoreTests.swift`
+
+**Interfaces:**
+- Consumes: `MessageStyles.style(id:)` and `MessageStyle` from Task 1.
+- Produces: `SettingsStore.messageStyleId: String` (persisted, UserDefaults key `"messageStyleId"`, default `"classic"`) and computed `SettingsStore.messageStyle: MessageStyle`. Tasks 4–6 rely on both names.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `SettingsStoreTests` suite in `Tests/StatusBarCoreTests/SettingsStoreTests.swift` (inside the suite, after `unknownDisplayStyleFallsBackToFull`):
+
+```swift
+    @Test func messageStyleDefaultsToClassic() {
+        let store = SettingsStore(defaults: makeDefaults())
+        #expect(store.messageStyleId == "classic")
+        #expect(store.messageStyle.id == "classic")
+    }
+
+    @Test func messageStyleIdPersistsAcrossInstances() {
+        let defaults = makeDefaults()
+        let store = SettingsStore(defaults: defaults)
+        store.messageStyleId = "pirate"
+        let reloaded = SettingsStore(defaults: defaults)
+        #expect(reloaded.messageStyleId == "pirate")
+        #expect(reloaded.messageStyle.id == "pirate")
+    }
+
+    @Test func unknownMessageStyleIdResolvesToClassicWithoutWriteBack() {
+        let defaults = makeDefaults()
+        defaults.set("vaporwave", forKey: "messageStyleId")
+        let store = SettingsStore(defaults: defaults)
+        #expect(store.messageStyle.id == "classic")
+        // The raw value is preserved — never rewritten to "classic".
+        #expect(store.messageStyleId == "vaporwave")
+        #expect(defaults.string(forKey: "messageStyleId") == "vaporwave")
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && swift test --filter SettingsStoreTests`
+Expected: BUILD FAILURE — `value of type 'SettingsStore' has no member 'messageStyleId'`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `Sources/StatusBarCore/Settings/SettingsStore.swift`:
+
+After the `hiddenAccounts` property (line 27), add:
+
+```swift
+    public var messageStyleId: String {
+        didSet { defaults.set(messageStyleId, forKey: "messageStyleId") }
+    }
+```
+
+After the computed `displayStyle` property (line 32), add:
+
+```swift
+    /// Total: an unknown persisted id falls back to Classic (never crashes,
+    /// never writes the fallback back to defaults).
+    public var messageStyle: MessageStyle {
+        MessageStyles.style(id: messageStyleId)
+    }
+```
+
+In `init`, after the `hiddenAccounts` line (line 41), add:
+
+```swift
+        messageStyleId = defaults.string(forKey: "messageStyleId") ?? "classic"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && swift test`
+Expected: PASS — 90 tests (87 + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && git add Sources/StatusBarCore/Settings/SettingsStore.swift Tests/StatusBarCoreTests/SettingsStoreTests.swift && git commit -m "feat: persist message style choice in SettingsStore"
+```
+
+---
+
+### Task 4: Theme MenuBarText output by message style
+
+**Files:**
+- Modify: `Sources/StatusBarCore/Display/MenuBarText.swift:15-36`
+- Modify: `Sources/ClaudeStatusBar/AppState.swift:91-98` (`labelModel` call site)
+- Test: `Tests/StatusBarCoreTests/MenuBarTextTests.swift`
+
+**Interfaces:**
+- Consumes: `MessageStyle`, `MessageStyles.style(id:)` (Task 1); `SettingsStore.messageStyle` (Task 3).
+- Produces: `MenuBarText.model(display:usage:style:showUsage:yellowAt:redAt:verb:messageStyle:now:)` — the new `messageStyle: MessageStyle` parameter sits between `verb:` and `now:`. (Spec wording says the parameter is named `style:`, but that label is taken by the existing `style: DisplayStyle`; this plan names it `messageStyle:` — see the plan header.) `.tool` renders `messageStyle.tool[label] ?? label`; `.waiting` renders `messageStyle.waiting`; `.thinking` keeps using the pre-picked `verb` argument verbatim. Formats unchanged: `Phrase… · 12s` / `Phrase · 12s`.
+
+- [ ] **Step 1: Update the test helper and write the new failing tests**
+
+In `Tests/StatusBarCoreTests/MenuBarTextTests.swift`, replace the private `model(...)` helper inside the `MenuBarTextTests` suite (lines 32–37) with:
+
+```swift
+    private func model(display: SessionRecord?, usage: AccountUsageState?,
+                       style: DisplayStyle, showUsage: Bool = true,
+                       messageStyle: MessageStyle = MessageStyles.style(id: "classic"))
+        -> MenuBarLabelModel {
+        MenuBarText.model(display: display, usage: usage, style: style,
+                          showUsage: showUsage, yellowAt: 50, redAt: 80,
+                          verb: "Pondering", messageStyle: messageStyle, now: now)
+    }
+```
+
+The classic default means every existing assertion in this suite (`"Running · 3m 12s"`, `"Pondering… · 45s"`, `"Waiting for you"`, …) keeps passing unchanged — that is the byte-identical regression check.
+
+Then add these tests inside the `MenuBarTextTests` suite, after `levelsComputedFromThresholds`:
+
+```swift
+    @Test func toolLabelThemedByStyle() {
+        let m = model(display: session(.tool, label: "Editing", busyFor: 192),
+                      usage: nil, style: .full,
+                      messageStyle: MessageStyles.style(id: "rpg"))
+        #expect(m.activityText == "Forging the blade · 3m 12s")
+    }
+
+    @Test func unknownToolLabelPassesThroughUnthemed() {
+        // Capitalized raw tool names from the hook fallback (e.g. WebFetch)
+        // are not in any style's map — they render as-is.
+        let m = model(display: session(.tool, label: "WebFetch", busyFor: 45),
+                      usage: nil, style: .full,
+                      messageStyle: MessageStyles.style(id: "pirate"))
+        #expect(m.activityText == "WebFetch · 45s")
+    }
+
+    @Test func missingLabelThemedAsWorking() {
+        let m = model(display: session(.tool, busyFor: 45), usage: nil, style: .full,
+                      messageStyle: MessageStyles.style(id: "scifi"))
+        #expect(m.activityText == "Running ship diagnostics · 45s")
+    }
+
+    @Test func waitingUsesStylePhrase() {
+        let m = model(display: session(.waiting, busyFor: 45), usage: nil, style: .full,
+                      messageStyle: MessageStyles.style(id: "cooking"))
+        #expect(m.activityText == "Order up, chef")
+    }
+
+    @Test func classicRendersByteIdenticalToV1() {
+        let tool = model(display: session(.tool, label: "Editing", busyFor: 12),
+                         usage: nil, style: .full)
+        #expect(tool.activityText == "Editing · 12s")
+        let waiting = model(display: session(.waiting, busyFor: 12), usage: nil, style: .full)
+        #expect(waiting.activityText == "Waiting for you")
+        let thinking = model(display: session(.thinking, busyFor: 12), usage: nil, style: .full)
+        #expect(thinking.activityText == "Pondering… · 12s")
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && swift test --filter MenuBarTextTests`
+Expected: BUILD FAILURE — `extra argument 'messageStyle' in call`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `Sources/StatusBarCore/Display/MenuBarText.swift`, change the `model` signature (lines 16–19) to:
+
+```swift
+    public static func model(display: SessionRecord?, usage: AccountUsageState?,
+                             style: DisplayStyle, showUsage: Bool,
+                             yellowAt: Double, redAt: Double,
+                             verb: String, messageStyle: MessageStyle,
+                             now: Date) -> MenuBarLabelModel {
+```
+
+and the activity switch (lines 26–35) to:
+
+```swift
+            switch display.state {
+            case .tool:
+                let label = display.label ?? "Working"
+                let phrase = messageStyle.tool[label] ?? label
+                activity = time.map { "\(phrase) · \($0)" } ?? phrase
+            case .thinking:
+                activity = time.map { "\(verb)… · \($0)" } ?? "\(verb)…"
+            case .waiting:
+                activity = messageStyle.waiting
+            case .idle:
+                activity = nil
+            }
+```
+
+In `Sources/ClaudeStatusBar/AppState.swift`, update `labelModel` (lines 94–97) to pass the active style:
+
+```swift
+        return MenuBarText.model(display: display, usage: activeUsage,
+                                 style: displayStyle, showUsage: showUsageOnBar,
+                                 yellowAt: yellowAt, redAt: redAt,
+                                 verb: currentVerb, messageStyle: settings.messageStyle,
+                                 now: Date())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && swift test`
+Expected: PASS — 95 tests (90 + 5 new). `swift build` must also succeed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && git add Sources/StatusBarCore/Display/MenuBarText.swift Sources/ClaudeStatusBar/AppState.swift Tests/StatusBarCoreTests/MenuBarTextTests.swift && git commit -m "feat: theme menu bar tool/waiting text by message style"
+```
+
+---
+
+### Task 5: AppState draws thinking phrases from the active style
+
+**Files:**
+- Modify: `Sources/ClaudeStatusBar/AppState.swift:44-46,77-84` (init verb pick, `reaggregate()`, new method)
+
+**Interfaces:**
+- Consumes: `SettingsStore.messageStyle` (Task 3); `VerbCycler.next(from:)` / `reset()` (Task 2).
+- Produces: `AppState.rerollThinkingPhrase()` (`@MainActor`, no arguments, no return) — Task 6's picker `.onChange` calls it by exactly this name.
+
+Note: `AppState` lives in the executable target, which the test target cannot import — verification for this task is `swift build` + the full core suite staying green (same convention as v1).
+
+- [ ] **Step 1: Write the implementation**
+
+In `Sources/ClaudeStatusBar/AppState.swift`:
+
+In `init` (lines 44–45), change:
+
+```swift
+        self.currentVerb = ThinkingVerbs.all[0]
+        self.currentVerb = verbCycler.next(from: ThinkingVerbs.all)
+```
+
+to:
+
+```swift
+        self.currentVerb = ThinkingVerbs.all[0]
+        self.currentVerb = verbCycler.next(from: self.settings.messageStyle.thinking)
+```
+
+(The `ThinkingVerbs.all[0]` placeholder stays: all stored properties must be initialized before `self.settings` can be read.)
+
+In `reaggregate()` (line 82), change:
+
+```swift
+            currentVerb = verbCycler.next(from: ThinkingVerbs.all)
+```
+
+to:
+
+```swift
+            currentVerb = verbCycler.next(from: settings.messageStyle.thinking)
+```
+
+After `reaggregate()` (below line 84), add:
+
+```swift
+    /// Called when the user picks a new message style: forget the no-repeat
+    /// memory (it indexes the old pool) and re-pick so a bar currently in
+    /// .thinking re-renders with the new style at once.
+    func rerollThinkingPhrase() {
+        verbCycler.reset()
+        currentVerb = verbCycler.next(from: settings.messageStyle.thinking)
+    }
+```
+
+- [ ] **Step 2: Verify the build and suite**
+
+Run: `cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && swift build && swift test`
+Expected: build succeeds; 95 tests PASS (no new unit tests — executable target).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && git add Sources/ClaudeStatusBar/AppState.swift && git commit -m "feat: draw thinking phrases from the active message style"
+```
+
+---
+
+### Task 6: Message style picker in Settings
+
+**Files:**
+- Modify: `Sources/ClaudeStatusBar/SettingsView.swift:11,25-54`
+
+**Interfaces:**
+- Consumes: `MessageStyles.all` (Task 1); `$settings.messageStyleId` (Task 3); `AppState.rerollThinkingPhrase()` (Task 5).
+- Produces: nothing consumed by later tasks (final task).
+
+- [ ] **Step 1: Write the implementation**
+
+In `Sources/ClaudeStatusBar/SettingsView.swift`:
+
+Line 11 — pass `appState` through to GeneralTab. Change:
+
+```swift
+            GeneralTab(settings: settings)
+```
+
+to:
+
+```swift
+            GeneralTab(appState: appState, settings: settings)
+```
+
+In `GeneralTab` (line 26), add the `appState` property above `settings`:
+
+```swift
+private struct GeneralTab: View {
+    let appState: AppState
+    @Bindable var settings: SettingsStore
+```
+
+Inside the `Form`, insert the picker between the "Display style" picker and the "Usage poll interval" picker (i.e. after line 48):
+
+```swift
+            Picker("Message style", selection: $settings.messageStyleId) {
+                ForEach(MessageStyles.all) { style in
+                    Text(style.name).tag(style.id)
+                }
+            }
+            .onChange(of: settings.messageStyleId) {
+                // Instant feedback: a bar currently in .thinking re-renders
+                // now; tool/waiting text re-themes on the next TimelineView
+                // tick (≤1 s).
+                appState.rerollThinkingPhrase()
+            }
+```
+
+- [ ] **Step 2: Verify the build and suite**
+
+Run: `cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && swift build && swift test`
+Expected: build succeeds; 95 tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/ser/scatola/jobs/projects/claude-status-bar-macos && git add Sources/ClaudeStatusBar/SettingsView.swift && git commit -m "feat: add Message style picker to Settings General tab"
+```
+
+---
+
+## Verification (whole feature)
+
+- `swift test` — 95 tests pass.
+- `bash scripts/hook-integration-test.sh` — 11 checks pass (hook untouched; this proves it).
+- `git diff main --stat` touches ONLY: `MessageStyles.swift` (new), `MessageStylesTests.swift` (new), `ThinkingVerbs.swift`, `MenuBarText.swift`, `SettingsStore.swift`, `AppState.swift`, `SettingsView.swift`, `MenuBarTextTests.swift`, `SettingsStoreTests.swift`, plus `docs/superpowers/`. Anything else (hook, SessionRecord, SessionsSection, StatusIcon) is a defect.
+- Manual (post-merge, user-owned): pick "Pirate" in Settings → General while a Claude session runs; the bar switches to pirate phrases immediately during thinking, within 1 s otherwise; popover text stays canonical.

--- a/docs/superpowers/specs/2026-07-11-message-styles-design.md
+++ b/docs/superpowers/specs/2026-07-11-message-styles-design.md
@@ -1,0 +1,230 @@
+# Message Styles — Design
+
+**Date:** 2026-07-11
+**Status:** Approved pending user spec review
+**Repo:** claude-status-bar-macos (base: main @ 5db72a4, v1 merged)
+
+## Goal
+
+Let the user pick a themed "message style" for the menu bar activity text.
+Each style rewrites what the bar says while Claude works — thinking phrases,
+tool-activity phrases, and the waiting text — as short English phrases
+(3–4 words each). The picker lives in Settings → General.
+
+## Background (current pipeline)
+
+- **Thinking** — `ThinkingVerbs.all` (28 single-word verbs) cycled by
+  `VerbCycler` (uniform random, never repeats the previous pick); rendered
+  as `Verb… · 12s`.
+- **Tool** — the hook binary maps tool names to canonical labels via
+  `ToolLabels.label(for:)` (`Editing`, `Running`, `Reading`, `Searching`,
+  `Browsing`, `Delegating`; unknown tools pass through capitalized;
+  missing tool name → `Working`) and **bakes the label string into the
+  session file**. The app renders `Label · 12s`.
+- **Waiting** — fixed `"Waiting for you"`.
+- The popover (`SessionsSection`) renders its own canonical state text,
+  independent of the menu bar.
+
+## Decisions (from brainstorming)
+
+1. **Scope: full theme.** A style rewrites all three groups: thinking pool,
+   tool labels, waiting text.
+2. **"Dump" example = Dumb** — intentionally goofy meme style.
+3. **Lineup: 7 styles** — Classic (default, preserves today's behavior
+   exactly) + RPG, Gardening, Dumb, Sci-Fi, Cooking, Pirate.
+4. **Approach: display-time theming.** The app maps canonical labels to
+   themed phrases at render time. Hook binary, session-file format, and
+   popover are untouched — no version-skew risk with already-installed
+   hooks, and style changes apply instantly to running sessions.
+
+## Architecture
+
+New file `Sources/StatusBarCore/Display/MessageStyles.swift`:
+
+```swift
+public struct MessageStyle: Identifiable, Sendable {
+    public let id: String              // "classic", "rpg", ...
+    public let name: String            // Picker display: "Classic", "RPG", ...
+    public let thinking: [String]      // phrase pool for state .thinking
+    public let tool: [String: String]  // canonical label -> themed phrase;
+                                       // keys: Editing, Running, Reading,
+                                       // Searching, Browsing, Delegating, Working
+    public let waiting: String
+}
+
+public enum MessageStyles {
+    public static let all: [MessageStyle]              // classic first
+    public static func style(id: String) -> MessageStyle  // unknown id -> classic
+}
+```
+
+Touched components (no other new files):
+
+- **`ThinkingVerbs.swift`** — `ThinkingVerbs.all` stays as-is (public API,
+  referenced by tests); it becomes the `thinking` pool of the `classic`
+  style. `VerbCycler` keeps its name but generalizes:
+  `mutating func next(from phrases: [String]) -> String` plus
+  `mutating func reset()`. Internal guard: if the remembered previous index
+  no longer fits the given pool (pool changed size), treat it as nil —
+  never index out of bounds. No-repeat rule unchanged.
+- **`MenuBarText.model(...)`** — gains a `style: MessageStyle` parameter.
+  `.tool` case: `style.tool[label] ?? label` (unknown pass-through labels
+  like `WebFetch` render unthemed). `.waiting` case: `style.waiting`.
+  The pre-picked `verb` parameter stays and is used verbatim for
+  `.thinking`. Formats unchanged: `Phrase… · 12s` / `Phrase · 12s`.
+- **`SettingsStore`** — new persisted property `messageStyleId: String`
+  (UserDefaults key `messageStyleId`, default `"classic"`) + computed
+  `messageStyle: MessageStyle` via `MessageStyles.style(id:)`.
+- **`AppState`** — `currentVerb` is drawn from the active style's
+  `thinking` pool (`verbCycler.next(from: settings.messageStyle.thinking)`);
+  new method `rerollThinkingPhrase()` resets the cycler and re-picks
+  `currentVerb` so a style switch updates the bar immediately.
+- **`SettingsView` (GeneralTab)** — gains `let appState: AppState`; new
+  `Picker("Message style", selection: $settings.messageStyleId)` listing
+  `MessageStyles.all` (`Text(style.name).tag(style.id)`), placed below
+  "Display style", with `.onChange(of: settings.messageStyleId)` calling
+  `appState.rerollThinkingPhrase()`.
+
+Untouched: hook binary, `SessionReducer`, session-file format,
+`SessionsSection` (popover), `StatusIcon`.
+
+## Style catalog
+
+All phrases are original (clean-room — nothing sourced from the KDE repo),
+English, and exactly 3–4 words for themed styles. Classic keeps today's
+single-word verbs and canonical labels, exempt from the word-count rule.
+
+### Classic (id `classic`, default)
+
+- **thinking:** `ThinkingVerbs.all` (the existing 28 verbs, unchanged)
+- **tool:** identity map — `Editing: "Editing"`, `Running: "Running"`,
+  `Reading: "Reading"`, `Searching: "Searching"`, `Browsing: "Browsing"`,
+  `Delegating: "Delegating"`, `Working: "Working"`
+- **waiting:** `Waiting for you`
+
+### RPG (id `rpg`)
+
+- **thinking (12):** Consulting the oracle · Rolling for wisdom ·
+  Studying ancient runes · Brewing mana potions · Sharpening the sword ·
+  Reading the prophecy · Charging the spell · Plotting the quest ·
+  Leveling up wisdom · Taming wild ideas · Gathering party buffs ·
+  Deciphering old glyphs
+- **tool:** Editing: `Forging the blade` · Running: `Casting the spell` ·
+  Reading: `Reading the scrolls` · Searching: `Scouting the dungeon` ·
+  Browsing: `Charting distant lands` · Delegating: `Summoning the party` ·
+  Working: `Grinding the XP`
+- **waiting:** `Awaiting your command`
+
+### Gardening (id `gardening`)
+
+- **thinking (12):** Watering the seedlings · Sprouting new ideas ·
+  Composting stray thoughts · Sowing fresh seeds · Sniffing the roses ·
+  Grafting wild branches · Mulching the beds · Sunning the sprouts ·
+  Repotting big ideas · Trimming the hedges · Feeding the roots ·
+  Warming the greenhouse
+- **tool:** Editing: `Pruning the branches` · Running: `Turning the soil` ·
+  Reading: `Reading seed packets` · Searching: `Hunting for weeds` ·
+  Browsing: `Visiting the nursery` · Delegating: `Hiring garden gnomes` ·
+  Working: `Tending the garden`
+- **waiting:** `Ripe for picking`
+
+### Dumb (id `dumb`)
+
+- **thinking (12):** Making think happen · Doing brain stuff ·
+  Vibing real hard · Loading smart thoughts · Buffering big brain ·
+  Thinking really hard · Consulting inner monologue · Staring at ceiling ·
+  Rebooting the noggin · Doing a ponder · Cooking hot takes ·
+  Charging brain cells
+- **tool:** Editing: `Typing many words` · Running: `Pressing big button` ·
+  Reading: `Looking at stuff` · Searching: `Finding the thing` ·
+  Browsing: `Surfing the webs` · Delegating: `Making friends work` ·
+  Working: `Doing the thing`
+- **waiting:** `Your turn buddy`
+
+### Sci-Fi (id `scifi`)
+
+- **thinking (12):** Computing warp trajectories · Consulting ship AI ·
+  Calibrating the sensors · Charging photon banks · Mapping wormhole routes ·
+  Decoding alien signals · Aligning the antenna · Simulating first contact ·
+  Cooling the reactor · Plotting orbital burns · Syncing quantum clocks ·
+  Scanning nebula clouds
+- **tool:** Editing: `Rewiring the core` · Running: `Firing the thrusters` ·
+  Reading: `Scanning data banks` · Searching: `Probing deep space` ·
+  Browsing: `Hailing distant stations` · Delegating: `Deploying drone fleet` ·
+  Working: `Running ship diagnostics`
+- **waiting:** `Awaiting your orders`
+
+### Cooking (id `cooking`)
+
+- **thinking (12):** Tasting the broth · Whisking fresh ideas ·
+  Reducing the sauce · Proofing the dough · Caramelizing the onions ·
+  Seasoning to taste · Simmering the stock · Kneading raw thoughts ·
+  Toasting the spices · Resting the roast · Glazing the tart ·
+  Julienning the details
+- **tool:** Editing: `Plating the dish` · Running: `Firing the stove` ·
+  Reading: `Reading the recipe` · Searching: `Raiding the pantry` ·
+  Browsing: `Shopping the market` · Delegating: `Calling sous chefs` ·
+  Working: `Prepping the ingredients`
+- **waiting:** `Order up, chef`
+
+### Pirate (id `pirate`)
+
+- **thinking (12):** Plotting the course · Reading the stars ·
+  Studying the charts · Counting gold doubloons · Eyeing the horizon ·
+  Trimming the mainsail · Whispering to parrots · Sniffing for treasure ·
+  Tying sailor knots · Weathering the storm · Charting hidden coves ·
+  Polishing the spyglass
+- **tool:** Editing: `Patching the sails` · Running: `Firing the cannons` ·
+  Reading: `Studying the map` · Searching: `Digging for treasure` ·
+  Browsing: `Scanning the horizon` · Delegating: `Rallying the crew` ·
+  Working: `Swabbing the deck`
+- **waiting:** `Cap'n needs orders`
+
+## Behavior
+
+- Style switch takes effect immediately: the picker's `onChange` re-rolls
+  the thinking phrase, so a bar currently in `.thinking` re-renders with
+  the new style at once; tool/waiting text re-themes on the next render
+  tick (≤1 s, the existing TimelineView cadence).
+- Persisted `messageStyleId` not matching any style (e.g. a style removed
+  in a future version) silently falls back to Classic — never crashes,
+  never writes back.
+- Thinking phrases keep cycling on each idle/tool → thinking transition,
+  never repeating the immediately previous phrase (existing rule).
+- The popover intentionally keeps canonical text (`Thinking`, `Editing`,
+  `Waiting for you`) — it is the functional detail view; the theme lives
+  only in the menu bar.
+
+## Error handling
+
+- `MessageStyles.style(id:)` total: any unknown id returns Classic.
+- `style.tool[label] ?? label` guarantees a printable label for tools the
+  map does not know (capitalized raw tool names from the hook fallback).
+- `VerbCycler.next(from:)` guards a stale previous index against the given
+  pool's size — safe across pools of different lengths.
+
+## Testing (swift-testing 0.12.0 API: `@Test`/`@Suite`/`#expect`/`#require`)
+
+- **Catalog invariants** — for every style in `MessageStyles.all`: all 7
+  tool keys present, non-empty thinking pool, non-empty waiting; for every
+  themed style (all except `classic`): every thinking/tool/waiting phrase
+  is 3–4 whitespace-separated words; ids unique; `classic` is first.
+- **Registry fallback** — `style(id: "nope")` returns classic;
+  `style(id: "pirate")` returns pirate.
+- **MenuBarText theming** — known label maps to themed phrase; unknown
+  label (`WebFetch`) passes through; waiting state renders `style.waiting`;
+  elapsed-time formats unchanged.
+- **Cycler** — no immediate repeat within a pool; switching to a smaller
+  pool never indexes out of bounds; `reset()` clears the no-repeat memory.
+- **SettingsStore** — `messageStyleId` persists and reloads; missing key
+  defaults to `"classic"`; unknown persisted id resolves to Classic via
+  `messageStyle`.
+- **Regression** — with default settings, menu bar output is byte-identical
+  to today: verbs drawn from `ThinkingVerbs.all`, tool state renders
+  `Editing · 12s`, waiting renders `Waiting for you`.
+
+## Out of scope
+
+- Theming the popover or the Clawd icon set per style.
+- User-defined/custom styles, per-style icons, localization.
+- Any hook binary or session-file format change.


### PR DESCRIPTION
## What

Themed **message styles** for the menu bar activity text. Pick a style in Settings → General and the bar's thinking / tool / waiting phrases re-theme instantly.

7 styles: **Classic** (default — byte-identical to v1) + RPG, Gardening, Dumb, Sci-Fi, Cooking, Pirate. Each themed style: 12 thinking + 7 tool + 1 waiting phrases, all exactly 3–4 words, all original (clean-room; nothing sourced from other status-bar projects).

## How

Display-time theming (spec's approach A): the app maps canonical labels to themed phrases at render time.

- New `MessageStyles` catalog + `MessageStyle` struct (`StatusBarCore/Display/MessageStyles.swift`); `style(id:)` is total — unknown ids fall back to Classic, never crash, never write back.
- `VerbCycler` generalized to `next(from:)`/`reset()` — safe across pools of different sizes, no-repeat rule unchanged.
- `MenuBarText.model(...)` gains `messageStyle:` (named so because `style:` already belongs to the `DisplayStyle` param — documented deviation from the spec sketch).
- `SettingsStore.messageStyleId` persisted (UserDefaults, default `"classic"`).
- `AppState` draws thinking phrases from the active pool; `rerollThinkingPhrase()` makes the picker switch instant.
- Settings → General: "Message style" picker below "Display style".

**Untouched:** hook binary, `SessionReducer`, session-file format, `StatusIcon`, and the popover — the popover intentionally keeps canonical text (`Thinking`, `Editing`, `Waiting for you`); the theme lives only in the menu bar.

No version-skew risk with already-installed hooks: the session-file format is unchanged.

## Verification

- `swift test`: **95/95** (77 pre-existing + 18 new: catalog invariants incl. 3–4-word rule for every themed phrase, classic-fallback, cycler pool-safety, theming, persistence round-trip, v1 byte-identity regression).
- `scripts/hook-integration-test.sh`: all checks pass.
- Diff scope: exactly the 9 planned source/test files + `docs/superpowers/` spec & plan.
- Per-task review after each of the 6 tasks + final whole-branch review: **0 Critical, 0 Important**; Minors triaged as fine-to-leave (notes in review: optional `precondition` on `next(from:)`'s empty-pool case; classic's identity tool map is deliberate so the 7-key invariant test stays uniform).

## Post-merge smoke (manual)

Switch style to **Pirate** in Settings → General while a Claude Code session runs: bar re-rolls instantly to a pirate thinking phrase; tool state shows e.g. `Patching the sails · 12s`; waiting shows `Cap'n needs orders`. Switch back to Classic → v1 text exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
