### PR TITLE
Make normal-usage color configurable

### DIFF
--- a/Sources/ClaudeStatusBar/AccountsSection.swift
+++ b/Sources/ClaudeStatusBar/AccountsSection.swift
@@ -6,6 +6,7 @@ struct AccountsSection: View {
     let states: [String: AccountUsageState]
     let yellowAt: Double
     let redAt: Double
+    let normalColor: Color
     let now: Date
     let onSwitch: (Account) -> Void
 
@@ -20,7 +21,7 @@ struct AccountsSection: View {
             } else {
                 ForEach(accounts) { account in
                     AccountRow(account: account, state: states[account.id],
-                               yellowAt: yellowAt, redAt: redAt, now: now,
+                               yellowAt: yellowAt, redAt: redAt, normalColor: normalColor, now: now,
                                showActiveBadge: accounts.count > 1, onSwitch: onSwitch)
                 }
             }
@@ -33,6 +34,7 @@ private struct AccountRow: View {
     let state: AccountUsageState?
     let yellowAt: Double
     let redAt: Double
+    let normalColor: Color
     let now: Date
     let showActiveBadge: Bool
     let onSwitch: (Account) -> Void
@@ -67,9 +69,9 @@ private struct AccountRow: View {
             }
             if let snapshot = state?.snapshot {
                 UsageBar(title: "5h", window: snapshot.fiveHour,
-                         yellowAt: yellowAt, redAt: redAt, now: now)
+                         yellowAt: yellowAt, redAt: redAt, normalColor: normalColor, now: now)
                 UsageBar(title: "7d", window: snapshot.sevenDay,
-                         yellowAt: yellowAt, redAt: redAt, now: now)
+                         yellowAt: yellowAt, redAt: redAt, normalColor: normalColor, now: now)
             } else {
                 Text("No usage data").font(.caption).foregroundStyle(.secondary)
             }
@@ -83,6 +85,7 @@ private struct UsageBar: View {
     let window: UsageWindow?
     let yellowAt: Double
     let redAt: Double
+    let normalColor: Color
     let now: Date
 
     var body: some View {
@@ -104,7 +107,7 @@ private struct UsageBar: View {
 
     private var color: Color {
         switch UsageLevel.level(for: window?.utilization ?? 0, yellowAt: yellowAt, redAt: redAt) {
-        case .green: return .green
+        case .green: return normalColor
         case .yellow: return .yellow
         case .red: return .red
         }

--- a/Sources/ClaudeStatusBar/ClaudeStatusBarApp.swift
+++ b/Sources/ClaudeStatusBar/ClaudeStatusBarApp.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import StatusBarCore
 
@@ -17,7 +18,8 @@ struct ClaudeStatusBarApp: App {
         } label: {
             MenuBarLabelView(model: appState.labelModel,
                              icon: StatusIcon.icon(for: appState.display),
-                             shimmerPhase: ShimmerText.phase(at: appState.tick))
+                             shimmerPhase: ShimmerText.phase(at: appState.tick),
+                             normalColor: NSColor(hex: appState.settings.normalColorHex) ?? .systemGreen)
                 .onAppear {
                     appState.start()
                     Task { await appState.refreshUsageNow() }

--- a/Sources/ClaudeStatusBar/ColorHex.swift
+++ b/Sources/ClaudeStatusBar/ColorHex.swift
@@ -1,0 +1,28 @@
+import AppKit
+import SwiftUI
+import StatusBarCore
+
+/// NSColor/Color bridges over StatusBarCore's framework-agnostic HexColor —
+/// SettingsStore persists the user's normal-usage color as a "#RRGGBB"
+/// string; the actual color types live here since StatusBarCore imports
+/// neither AppKit nor SwiftUI.
+extension NSColor {
+    convenience init?(hex: String) {
+        guard let c = HexColor.components(hex: hex) else { return nil }
+        self.init(srgbRed: c.r, green: c.g, blue: c.b, alpha: 1)
+    }
+}
+
+extension Color {
+    init?(hex: String) {
+        guard let c = HexColor.components(hex: hex) else { return nil }
+        self.init(.sRGB, red: c.r, green: c.g, blue: c.b, opacity: 1)
+    }
+
+    /// Round-trips a ColorPicker selection back to the hex string
+    /// SettingsStore persists.
+    var hexString: String {
+        let ns = NSColor(self).usingColorSpace(.sRGB) ?? NSColor(self)
+        return HexColor.hex(r: ns.redComponent, g: ns.greenComponent, b: ns.blueComponent)
+    }
+}

--- a/Sources/ClaudeStatusBar/LabelComposite.swift
+++ b/Sources/ClaudeStatusBar/LabelComposite.swift
@@ -12,7 +12,7 @@ enum LabelComposite {
     static let height: CGFloat = 24
 
     static func image(model: MenuBarLabelModel, icon: ClawdIcon,
-                      shimmerPhase: Double, dark: Bool) -> NSImage {
+                      shimmerPhase: Double, dark: Bool, normalColor: NSColor) -> NSImage {
         let busy = model.state == .thinking || model.state == .tool
         let activity: (image: NSImage, offsetY: CGFloat)? = model.activityText.map { text in
             let baked = busy
@@ -24,7 +24,7 @@ enum LabelComposite {
                                         shimmerPhase: shimmerPhase, dark: dark)
         let usage = model.usageText.map { text in
             (image: ShimmerText.plain(text, dark: dark, monospacedDigits: true,
-                                      color: color(for: model.usageLevel)),
+                                      color: color(for: model.usageLevel, normalColor: normalColor)),
              offsetY: CGFloat(0))
         }
 
@@ -57,10 +57,11 @@ enum LabelComposite {
     /// Mirrors the popover's `UsageBar.color` convention so the status-bar
     /// percentage and the per-account bars agree on what "getting close"
     /// looks like. nil (no usage shown, or level unknown) keeps the default
-    /// monochrome text color.
-    private static func color(for level: UsageLevel?) -> NSColor? {
+    /// monochrome text color. Only the "normal" (green) level is user
+    /// configurable — yellow/red stay hardcoded system colors.
+    private static func color(for level: UsageLevel?, normalColor: NSColor) -> NSColor? {
         switch level {
-        case .green: return .systemGreen
+        case .green: return normalColor
         case .yellow: return .systemYellow
         case .red: return .systemRed
         case nil: return nil

--- a/Sources/ClaudeStatusBar/MenuBarLabelView.swift
+++ b/Sources/ClaudeStatusBar/MenuBarLabelView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import StatusBarCore
 
@@ -5,6 +6,7 @@ struct MenuBarLabelView: View {
     let model: MenuBarLabelModel
     let icon: ClawdIcon
     var shimmerPhase: Double = 0
+    let normalColor: NSColor
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
@@ -14,7 +16,8 @@ struct MenuBarLabelView: View {
         // or keep more than one image.
         Image(nsImage: LabelComposite.image(model: model, icon: icon,
                                             shimmerPhase: shimmerPhase,
-                                            dark: colorScheme == .dark))
+                                            dark: colorScheme == .dark,
+                                            normalColor: normalColor))
             .renderingMode(.original)
     }
 }

--- a/Sources/ClaudeStatusBar/PopoverView.swift
+++ b/Sources/ClaudeStatusBar/PopoverView.swift
@@ -14,6 +14,7 @@ struct PopoverView: View {
                 AccountsSection(accounts: appState.visibleAccounts,
                                 states: appState.usageStore.states,
                                 yellowAt: appState.yellowAt, redAt: appState.redAt,
+                                normalColor: Color(hex: appState.settings.normalColorHex) ?? .green,
                                 now: context.date,
                                 onSwitch: { account in
                                     Task { await appState.switchAccount(account) }

--- a/Sources/ClaudeStatusBar/SettingsView.swift
+++ b/Sources/ClaudeStatusBar/SettingsView.swift
@@ -93,8 +93,18 @@ private struct ThresholdsTab: View {
                 Text("Red threshold should be above yellow")
                     .font(.caption).foregroundStyle(.orange)
             }
+            ColorPicker("Normal usage color", selection: normalColorBinding)
         }
         .padding(20)
+    }
+
+    /// Bridges SettingsStore's persisted hex string to a picker-friendly
+    /// Color; malformed hex (only reachable via manually-edited defaults)
+    /// falls back to the default green rather than crashing.
+    private var normalColorBinding: Binding<Color> {
+        Binding(
+            get: { Color(hex: settings.normalColorHex) ?? .green },
+            set: { settings.normalColorHex = $0.hexString })
     }
 }
 

--- a/Sources/StatusBarCore/Settings/HexColor.swift
+++ b/Sources/StatusBarCore/Settings/HexColor.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Minimal sRGB hex ("#RRGGBB") <-> component conversion for persisted
+/// colors. UserDefaults has no native NSColor/Color type, so SettingsStore
+/// persists colors as hex strings; StatusBarCore stays framework-agnostic
+/// (no AppKit/SwiftUI import anywhere in this target), so this only exposes
+/// plain component doubles — NSColor/Color construction happens in the app
+/// target that actually needs each type.
+public enum HexColor {
+    /// Parses "#RRGGBB" (leading "#" optional, case-insensitive) into sRGB
+    /// components in 0...1. Malformed input (wrong length, non-hex digits)
+    /// returns nil.
+    public static func components(hex: String) -> (r: Double, g: Double, b: Double)? {
+        var s = hex
+        if s.hasPrefix("#") { s.removeFirst() }
+        guard s.count == 6, let value = UInt32(s, radix: 16) else { return nil }
+        return (Double((value >> 16) & 0xFF) / 255,
+                Double((value >> 8) & 0xFF) / 255,
+                Double(value & 0xFF) / 255)
+    }
+
+    /// Formats sRGB components (each clamped to 0...1) back to "#RRGGBB".
+    public static func hex(r: Double, g: Double, b: Double) -> String {
+        func byte(_ v: Double) -> Int { Int((min(max(v, 0), 1) * 255).rounded()) }
+        return String(format: "#%02X%02X%02X", byte(r), byte(g), byte(b))
+    }
+}

--- a/Sources/StatusBarCore/Settings/SettingsStore.swift
+++ b/Sources/StatusBarCore/Settings/SettingsStore.swift
@@ -31,6 +31,13 @@ public final class SettingsStore {
     public var messageStyleId: String {
         didSet { defaults.set(messageStyleId, forKey: "messageStyleId") }
     }
+    /// Hex ("#RRGGBB") for the "normal" (below-yellow) usage level; yellow
+    /// and red stay hardcoded system colors. Default is NSColor.systemGreen's
+    /// sRGB hex, so a fresh install renders identically to the old hardcoded
+    /// color.
+    public var normalColorHex: String {
+        didSet { defaults.set(normalColorHex, forKey: "normalColorHex") }
+    }
 
     public var displayStyle: DisplayStyle {
         get { DisplayStyle(rawValue: displayStyleRaw) ?? .full }
@@ -53,5 +60,6 @@ public final class SettingsStore {
         redAt = defaults.object(forKey: "redAt") as? Double ?? 80
         hiddenAccounts = defaults.stringArray(forKey: "hiddenAccounts") ?? []
         messageStyleId = defaults.string(forKey: "messageStyleId") ?? "classic"
+        normalColorHex = defaults.string(forKey: "normalColorHex") ?? "#34C759"
     }
 }

--- a/Tests/StatusBarCoreTests/HexColorTests.swift
+++ b/Tests/StatusBarCoreTests/HexColorTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+@testable import StatusBarCore
+
+@Suite struct HexColorTests {
+    @Test func parsesRRGGBB() {
+        let c = HexColor.components(hex: "#34C759")
+        #expect(c != nil)
+        #expect(abs(c!.r - Double(0x34) / 255) < 0.001)
+        #expect(abs(c!.g - Double(0xC7) / 255) < 0.001)
+        #expect(abs(c!.b - Double(0x59) / 255) < 0.001)
+    }
+
+    @Test func parsesWithoutLeadingHash() {
+        #expect(HexColor.components(hex: "34C759") != nil)
+    }
+
+    @Test func lowercaseHexParses() {
+        #expect(HexColor.components(hex: "#34c759") != nil)
+    }
+
+    @Test func malformedHexReturnsNil() {
+        #expect(HexColor.components(hex: "#ZZZZZZ") == nil)
+        #expect(HexColor.components(hex: "#ABC") == nil)
+        #expect(HexColor.components(hex: "") == nil)
+    }
+
+    @Test func formatsRoundTrip() {
+        let hex = HexColor.hex(r: Double(0x34) / 255, g: Double(0xC7) / 255, b: Double(0x59) / 255)
+        #expect(hex == "#34C759")
+    }
+
+    @Test func formatClampsOutOfRangeComponents() {
+        #expect(HexColor.hex(r: -1, g: 2, b: 0.5) == "#00FF80")
+    }
+}

--- a/Tests/StatusBarCoreTests/SettingsStoreTests.swift
+++ b/Tests/StatusBarCoreTests/SettingsStoreTests.swift
@@ -19,6 +19,7 @@ import Testing
         #expect(store.yellowAt == 50)
         #expect(store.redAt == 80)
         #expect(store.hiddenAccounts.isEmpty)
+        #expect(store.normalColorHex == "#34C759")
     }
 
     @Test func persistsAcrossInstances() {
@@ -31,6 +32,7 @@ import Testing
         store.yellowAt = 40
         store.redAt = 90
         store.hiddenAccounts = ["slot-2"]
+        store.normalColorHex = "#112233"
 
         let reloaded = SettingsStore(defaults: defaults)
         #expect(reloaded.showUsageOnBar == false)
@@ -40,6 +42,7 @@ import Testing
         #expect(reloaded.yellowAt == 40)
         #expect(reloaded.redAt == 90)
         #expect(reloaded.hiddenAccounts == ["slot-2"])
+        #expect(reloaded.normalColorHex == "#112233")
     }
 
     @Test func unknownDisplayStyleFallsBackToFull() {


### PR DESCRIPTION
## Summary
- Green was hardcoded for the "normal" (below-yellow) usage level in both the menu bar text and the popover's per-account bars — the color shown most of the time, with no way to fix poor contrast against a given menu bar background.
- Adds a `ColorPicker` in Settings → Thresholds; persisted as a hex string in `SettingsStore` (`normalColorHex`, default `#34C759` = `NSColor.systemGreen`'s sRGB hex, so existing installs render unchanged).
- Yellow/red stay hardcoded alert colors. Shimmer/activity text is untouched (separate code path).

## Test plan
- [x] `swift test` — 143/143 passing
- [x] `make app` — builds clean
- [ ] Visual: pick a custom color in Settings → Thresholds, confirm it shows in both the menu bar percentage and popover usage bars
- [ ] Visual: fresh install / no saved pref renders identically to the old hardcoded green

🤖 Generated with [Claude Code](https://claude.com/claude-code)