### PR TITLE
Smooth activity-text shimmer to 30fps, add disable toggle

### DIFF
--- a/Sources/ClaudeStatusBar/AppState.swift
+++ b/Sources/ClaudeStatusBar/AppState.swift
@@ -117,7 +117,7 @@ final class AppState {
         }
     }
 
-    /// Drives the elapsed counter and shimmer while a session is busy — 8 fps
+    /// Drives the elapsed counter and shimmer while a session is busy — 30 fps
     /// when activity text is on the bar (the shimmer needs sub-second frames),
     /// 1 Hz for icon-only/compact styles. A plain task loop, not TimelineView:
     /// a periodic TimelineView in the MenuBarExtra label re-anchors its
@@ -127,13 +127,13 @@ final class AppState {
     private func updateTicker() {
         if display?.busySince != nil {
             let interval: Duration = displayStyle == .iconOnly || displayStyle == .compact
-                ? .seconds(1) : .milliseconds(125)
+                ? .seconds(1) : .milliseconds(33)
             guard tickTask == nil || interval != tickInterval else { return }
             tickTask?.cancel()
             tickInterval = interval
             tick = Date()
             // DIAGNOSTIC(shimmer):
-            tickerLog.info("ticker start interval=\(interval == .seconds(1) ? "1s" : "125ms", privacy: .public) style=\(String(describing: self.displayStyle), privacy: .public) state=\(String(describing: self.display?.state), privacy: .public)")
+            tickerLog.info("ticker start interval=\(interval == .seconds(1) ? "1s" : "33ms", privacy: .public) style=\(String(describing: self.displayStyle), privacy: .public) state=\(String(describing: self.display?.state), privacy: .public)")
             tickTask = Task { [weak self] in
                 while !Task.isCancelled {
                     try? await Task.sleep(for: interval)

--- a/Sources/ClaudeStatusBar/ClaudeStatusBarApp.swift
+++ b/Sources/ClaudeStatusBar/ClaudeStatusBarApp.swift
@@ -19,7 +19,8 @@ struct ClaudeStatusBarApp: App {
             MenuBarLabelView(model: appState.labelModel,
                              icon: StatusIcon.icon(for: appState.display),
                              shimmerPhase: ShimmerText.phase(at: appState.tick),
-                             normalColor: NSColor(hex: appState.settings.normalColorHex) ?? .systemGreen)
+                             normalColor: NSColor(hex: appState.settings.normalColorHex) ?? .systemGreen,
+                             animateText: appState.settings.textAnimationEnabled)
                 .onAppear {
                     appState.start()
                     Task { await appState.refreshUsageNow() }

--- a/Sources/ClaudeStatusBar/LabelComposite.swift
+++ b/Sources/ClaudeStatusBar/LabelComposite.swift
@@ -12,10 +12,11 @@ enum LabelComposite {
     static let height: CGFloat = 24
 
     static func image(model: MenuBarLabelModel, icon: ClawdIcon,
-                      shimmerPhase: Double, dark: Bool, normalColor: NSColor) -> NSImage {
+                      shimmerPhase: Double, dark: Bool, normalColor: NSColor,
+                      animateText: Bool) -> NSImage {
         let busy = model.state == .thinking || model.state == .tool
         let activity: (image: NSImage, offsetY: CGFloat)? = model.activityText.map { text in
-            let baked = busy
+            let baked = (busy && animateText)
                 ? ShimmerText.image(text, phase: shimmerPhase, dark: dark)
                 : ShimmerText.plain(text, dark: dark)
             return (image: baked, offsetY: 0)
@@ -82,7 +83,7 @@ enum LabelComposite {
         return frames[min(Int(shimmerPhase * Double(frames.count)), frames.count - 1)]
     }
 
-    /// Decoded animation frames cached per icon — the busy tick renders 8
+    /// Decoded animation frames cached per icon — the busy tick renders 30
     /// times a second and must not touch the disk.
     private static var frameCache: [ClawdIcon: [(image: NSImage, offsetY: CGFloat)]] = [:]
 
@@ -108,7 +109,7 @@ enum LabelComposite {
     }
 
     /// Decoded PNGs cached per icon case — the busy tick would otherwise
-    /// re-read and re-decode the same file from disk 8 times a second.
+    /// re-read and re-decode the same file from disk 30 times a second.
     private static var imageCache: [ClawdIcon: (image: NSImage, offsetY: CGFloat)] = [:]
 
     private static func cachedImage(for icon: ClawdIcon,

--- a/Sources/ClaudeStatusBar/MenuBarLabelView.swift
+++ b/Sources/ClaudeStatusBar/MenuBarLabelView.swift
@@ -7,6 +7,7 @@ struct MenuBarLabelView: View {
     let icon: ClawdIcon
     var shimmerPhase: Double = 0
     let normalColor: NSColor
+    let animateText: Bool
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
@@ -17,7 +18,8 @@ struct MenuBarLabelView: View {
         Image(nsImage: LabelComposite.image(model: model, icon: icon,
                                             shimmerPhase: shimmerPhase,
                                             dark: colorScheme == .dark,
-                                            normalColor: normalColor))
+                                            normalColor: normalColor,
+                                            animateText: animateText))
             .renderingMode(.original)
     }
 }

--- a/Sources/ClaudeStatusBar/SettingsView.swift
+++ b/Sources/ClaudeStatusBar/SettingsView.swift
@@ -43,6 +43,7 @@ private struct GeneralTab: View {
                 }
             Toggle("Show usage on menu bar", isOn: $settings.showUsageOnBar)
             Toggle("Show elapsed time on menu bar", isOn: $settings.showElapsedOnBar)
+            Toggle("Animate activity text", isOn: $settings.textAnimationEnabled)
             // 🦀 stands in for the Clawd icon in each sample.
             Picker("Display style", selection: $settings.displayStyle) {
                 Text("Icon only — 🦀").tag(DisplayStyle.iconOnly)

--- a/Sources/ClaudeStatusBar/ShimmerText.swift
+++ b/Sources/ClaudeStatusBar/ShimmerText.swift
@@ -37,7 +37,7 @@ enum ShimmerText {
     }
 
     /// 0..<1 position of the sweep at `date`; feed `AppState.tick` so every
-    /// 8 fps tick advances the band.
+    /// 30 fps tick advances the band.
     static func phase(at date: Date) -> Double {
         let t = date.timeIntervalSinceReferenceDate
         return t.truncatingRemainder(dividingBy: period) / period

--- a/Sources/StatusBarCore/Settings/SettingsStore.swift
+++ b/Sources/StatusBarCore/Settings/SettingsStore.swift
@@ -38,6 +38,9 @@ public final class SettingsStore {
     public var normalColorHex: String {
         didSet { defaults.set(normalColorHex, forKey: "normalColorHex") }
     }
+    public var textAnimationEnabled: Bool {
+        didSet { defaults.set(textAnimationEnabled, forKey: "textAnimationEnabled") }
+    }
 
     public var displayStyle: DisplayStyle {
         get { DisplayStyle(rawValue: displayStyleRaw) ?? .full }
@@ -61,5 +64,6 @@ public final class SettingsStore {
         hiddenAccounts = defaults.stringArray(forKey: "hiddenAccounts") ?? []
         messageStyleId = defaults.string(forKey: "messageStyleId") ?? "classic"
         normalColorHex = defaults.string(forKey: "normalColorHex") ?? "#34C759"
+        textAnimationEnabled = defaults.object(forKey: "textAnimationEnabled") as? Bool ?? true
     }
 }

--- a/Tests/StatusBarCoreTests/SettingsStoreTests.swift
+++ b/Tests/StatusBarCoreTests/SettingsStoreTests.swift
@@ -20,6 +20,7 @@ import Testing
         #expect(store.redAt == 80)
         #expect(store.hiddenAccounts.isEmpty)
         #expect(store.normalColorHex == "#34C759")
+        #expect(store.textAnimationEnabled == true)
     }
 
     @Test func persistsAcrossInstances() {
@@ -33,6 +34,7 @@ import Testing
         store.redAt = 90
         store.hiddenAccounts = ["slot-2"]
         store.normalColorHex = "#112233"
+        store.textAnimationEnabled = false
 
         let reloaded = SettingsStore(defaults: defaults)
         #expect(reloaded.showUsageOnBar == false)
@@ -43,6 +45,7 @@ import Testing
         #expect(reloaded.redAt == 90)
         #expect(reloaded.hiddenAccounts == ["slot-2"])
         #expect(reloaded.normalColorHex == "#112233")
+        #expect(reloaded.textAnimationEnabled == false)
     }
 
     @Test func unknownDisplayStyleFallsBackToFull() {


### PR DESCRIPTION
## Summary
- Bump the activity-text shimmer/ticker interval from 125ms (8 fps) to 33ms (~30 fps) for a smoother sweep. The 1 Hz icon-only/compact branch is untouched.
- Add a "Animate activity text" Settings toggle (`SettingsStore.textAnimationEnabled`, default `true`) that lets users disable the shimmer sweep and fall back to static activity text while busy. The Clawd icon's own busy-state frame animation is unaffected — only the text-baking branch in `LabelComposite.image` is gated.
- Updated the "8 fps" / "125ms" / "8 times a second" comments and the `tickerLog` string literal to match the new rate.

## Test plan
- `swift test` — 143 tests passed (including new default + persistence coverage for `textAnimationEnabled` in `SettingsStoreTests.swift`).
- `make app` — builds clean, produces `dist/ClaudeStatusBar.app`.
- Manual checks still needed (not verifiable headlessly):
  - Shimmer visually reads as smoother at 30fps vs the old 8fps.
  - Toggling "Animate activity text" off in Settings makes the busy activity text render static/plain immediately (no sweep).
  - Clawd icon animation still plays normally regardless of the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
