### PR TITLE
Make yellow/red usage colors configurable

### DIFF
--- a/Sources/ClaudeStatusBar/AccountsSection.swift
+++ b/Sources/ClaudeStatusBar/AccountsSection.swift
@@ -7,6 +7,8 @@ struct AccountsSection: View {
     let yellowAt: Double
     let redAt: Double
     let normalColor: Color
+    let yellowColor: Color
+    let redColor: Color
     let now: Date
     let onSwitch: (Account) -> Void
 
@@ -21,7 +23,8 @@ struct AccountsSection: View {
             } else {
                 ForEach(accounts) { account in
                     AccountRow(account: account, state: states[account.id],
-                               yellowAt: yellowAt, redAt: redAt, normalColor: normalColor, now: now,
+                               yellowAt: yellowAt, redAt: redAt, normalColor: normalColor,
+                               yellowColor: yellowColor, redColor: redColor, now: now,
                                showActiveBadge: accounts.count > 1, onSwitch: onSwitch)
                 }
             }
@@ -35,6 +38,8 @@ private struct AccountRow: View {
     let yellowAt: Double
     let redAt: Double
     let normalColor: Color
+    let yellowColor: Color
+    let redColor: Color
     let now: Date
     let showActiveBadge: Bool
     let onSwitch: (Account) -> Void
@@ -69,9 +74,11 @@ private struct AccountRow: View {
             }
             if let snapshot = state?.snapshot {
                 UsageBar(title: "5h", window: snapshot.fiveHour,
-                         yellowAt: yellowAt, redAt: redAt, normalColor: normalColor, now: now)
+                         yellowAt: yellowAt, redAt: redAt, normalColor: normalColor,
+                         yellowColor: yellowColor, redColor: redColor, now: now)
                 UsageBar(title: "7d", window: snapshot.sevenDay,
-                         yellowAt: yellowAt, redAt: redAt, normalColor: normalColor, now: now)
+                         yellowAt: yellowAt, redAt: redAt, normalColor: normalColor,
+                         yellowColor: yellowColor, redColor: redColor, now: now)
             } else {
                 Text("No usage data").font(.caption).foregroundStyle(.secondary)
             }
@@ -86,6 +93,8 @@ private struct UsageBar: View {
     let yellowAt: Double
     let redAt: Double
     let normalColor: Color
+    let yellowColor: Color
+    let redColor: Color
     let now: Date
 
     var body: some View {
@@ -108,8 +117,8 @@ private struct UsageBar: View {
     private var color: Color {
         switch UsageLevel.level(for: window?.utilization ?? 0, yellowAt: yellowAt, redAt: redAt) {
         case .green: return normalColor
-        case .yellow: return .yellow
-        case .red: return .red
+        case .yellow: return yellowColor
+        case .red: return redColor
         }
     }
 }

--- a/Sources/ClaudeStatusBar/ClaudeStatusBarApp.swift
+++ b/Sources/ClaudeStatusBar/ClaudeStatusBarApp.swift
@@ -19,7 +19,9 @@ struct ClaudeStatusBarApp: App {
             MenuBarLabelView(model: appState.labelModel,
                              icon: StatusIcon.icon(for: appState.display),
                              shimmerPhase: ShimmerText.phase(at: appState.tick),
-                             normalColor: NSColor(hex: appState.settings.normalColorHex) ?? .systemGreen)
+                             normalColor: NSColor(hex: appState.settings.normalColorHex) ?? .systemGreen,
+                             yellowColor: NSColor(hex: appState.settings.yellowColorHex) ?? .systemYellow,
+                             redColor: NSColor(hex: appState.settings.redColorHex) ?? .systemRed)
                 .onAppear {
                     appState.start()
                     Task { await appState.refreshUsageNow() }

--- a/Sources/ClaudeStatusBar/LabelComposite.swift
+++ b/Sources/ClaudeStatusBar/LabelComposite.swift
@@ -12,7 +12,8 @@ enum LabelComposite {
     static let height: CGFloat = 24
 
     static func image(model: MenuBarLabelModel, icon: ClawdIcon,
-                      shimmerPhase: Double, dark: Bool, normalColor: NSColor) -> NSImage {
+                      shimmerPhase: Double, dark: Bool, normalColor: NSColor,
+                      yellowColor: NSColor, redColor: NSColor) -> NSImage {
         let busy = model.state == .thinking || model.state == .tool
         let activity: (image: NSImage, offsetY: CGFloat)? = model.activityText.map { text in
             let baked = busy
@@ -24,7 +25,8 @@ enum LabelComposite {
                                         shimmerPhase: shimmerPhase, dark: dark)
         let usage = model.usageText.map { text in
             (image: ShimmerText.plain(text, dark: dark, monospacedDigits: true,
-                                      color: color(for: model.usageLevel, normalColor: normalColor)),
+                                      color: color(for: model.usageLevel, normalColor: normalColor,
+                                                   yellowColor: yellowColor, redColor: redColor)),
              offsetY: CGFloat(0))
         }
 
@@ -57,13 +59,14 @@ enum LabelComposite {
     /// Mirrors the popover's `UsageBar.color` convention so the status-bar
     /// percentage and the per-account bars agree on what "getting close"
     /// looks like. nil (no usage shown, or level unknown) keeps the default
-    /// monochrome text color. Only the "normal" (green) level is user
-    /// configurable — yellow/red stay hardcoded system colors.
-    private static func color(for level: UsageLevel?, normalColor: NSColor) -> NSColor? {
+    /// monochrome text color. All three levels (normal/yellow/red) are user
+    /// configurable.
+    private static func color(for level: UsageLevel?, normalColor: NSColor,
+                              yellowColor: NSColor, redColor: NSColor) -> NSColor? {
         switch level {
         case .green: return normalColor
-        case .yellow: return .systemYellow
-        case .red: return .systemRed
+        case .yellow: return yellowColor
+        case .red: return redColor
         case nil: return nil
         }
     }

--- a/Sources/ClaudeStatusBar/MenuBarLabelView.swift
+++ b/Sources/ClaudeStatusBar/MenuBarLabelView.swift
@@ -7,6 +7,8 @@ struct MenuBarLabelView: View {
     let icon: ClawdIcon
     var shimmerPhase: Double = 0
     let normalColor: NSColor
+    let yellowColor: NSColor
+    let redColor: NSColor
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
@@ -17,7 +19,9 @@ struct MenuBarLabelView: View {
         Image(nsImage: LabelComposite.image(model: model, icon: icon,
                                             shimmerPhase: shimmerPhase,
                                             dark: colorScheme == .dark,
-                                            normalColor: normalColor))
+                                            normalColor: normalColor,
+                                            yellowColor: yellowColor,
+                                            redColor: redColor))
             .renderingMode(.original)
     }
 }

--- a/Sources/ClaudeStatusBar/PopoverView.swift
+++ b/Sources/ClaudeStatusBar/PopoverView.swift
@@ -15,6 +15,8 @@ struct PopoverView: View {
                                 states: appState.usageStore.states,
                                 yellowAt: appState.yellowAt, redAt: appState.redAt,
                                 normalColor: Color(hex: appState.settings.normalColorHex) ?? .green,
+                                yellowColor: Color(hex: appState.settings.yellowColorHex) ?? .yellow,
+                                redColor: Color(hex: appState.settings.redColorHex) ?? .red,
                                 now: context.date,
                                 onSwitch: { account in
                                     Task { await appState.switchAccount(account) }

--- a/Sources/ClaudeStatusBar/SettingsView.swift
+++ b/Sources/ClaudeStatusBar/SettingsView.swift
@@ -83,17 +83,19 @@ private struct ThresholdsTab: View {
 
     var body: some View {
         Form {
+            ColorPicker("Normal usage color", selection: normalColorBinding)
             Slider(value: $settings.yellowAt, in: 10...90, step: 5) {
                 Text("Yellow from \(Int(settings.yellowAt))%")
             }
+            ColorPicker("Yellow usage color", selection: yellowColorBinding)
             Slider(value: $settings.redAt, in: 20...100, step: 5) {
                 Text("Red from \(Int(settings.redAt))%")
             }
+            ColorPicker("Red usage color", selection: redColorBinding)
             if settings.redAt <= settings.yellowAt {
                 Text("Red threshold should be above yellow")
                     .font(.caption).foregroundStyle(.orange)
             }
-            ColorPicker("Normal usage color", selection: normalColorBinding)
         }
         .padding(20)
     }
@@ -105,6 +107,20 @@ private struct ThresholdsTab: View {
         Binding(
             get: { Color(hex: settings.normalColorHex) ?? .green },
             set: { settings.normalColorHex = $0.hexString })
+    }
+
+    /// Same bridge as `normalColorBinding`, for the yellow usage level.
+    private var yellowColorBinding: Binding<Color> {
+        Binding(
+            get: { Color(hex: settings.yellowColorHex) ?? .yellow },
+            set: { settings.yellowColorHex = $0.hexString })
+    }
+
+    /// Same bridge as `normalColorBinding`, for the red usage level.
+    private var redColorBinding: Binding<Color> {
+        Binding(
+            get: { Color(hex: settings.redColorHex) ?? .red },
+            set: { settings.redColorHex = $0.hexString })
     }
 }
 

--- a/Sources/StatusBarCore/Settings/SettingsStore.swift
+++ b/Sources/StatusBarCore/Settings/SettingsStore.swift
@@ -38,6 +38,18 @@ public final class SettingsStore {
     public var normalColorHex: String {
         didSet { defaults.set(normalColorHex, forKey: "normalColorHex") }
     }
+    /// Hex ("#RRGGBB") for the yellow (mid) usage level. Default is
+    /// NSColor.systemYellow's sRGB hex, so a fresh install renders
+    /// identically to the old hardcoded color.
+    public var yellowColorHex: String {
+        didSet { defaults.set(yellowColorHex, forKey: "yellowColorHex") }
+    }
+    /// Hex ("#RRGGBB") for the red (high) usage level. Default is
+    /// NSColor.systemRed's sRGB hex, so a fresh install renders
+    /// identically to the old hardcoded color.
+    public var redColorHex: String {
+        didSet { defaults.set(redColorHex, forKey: "redColorHex") }
+    }
 
     public var displayStyle: DisplayStyle {
         get { DisplayStyle(rawValue: displayStyleRaw) ?? .full }
@@ -61,5 +73,7 @@ public final class SettingsStore {
         hiddenAccounts = defaults.stringArray(forKey: "hiddenAccounts") ?? []
         messageStyleId = defaults.string(forKey: "messageStyleId") ?? "classic"
         normalColorHex = defaults.string(forKey: "normalColorHex") ?? "#34C759"
+        yellowColorHex = defaults.string(forKey: "yellowColorHex") ?? "#FFCC00"
+        redColorHex = defaults.string(forKey: "redColorHex") ?? "#FF3B30"
     }
 }

--- a/Tests/StatusBarCoreTests/SettingsStoreTests.swift
+++ b/Tests/StatusBarCoreTests/SettingsStoreTests.swift
@@ -20,6 +20,8 @@ import Testing
         #expect(store.redAt == 80)
         #expect(store.hiddenAccounts.isEmpty)
         #expect(store.normalColorHex == "#34C759")
+        #expect(store.yellowColorHex == "#FFCC00")
+        #expect(store.redColorHex == "#FF3B30")
     }
 
     @Test func persistsAcrossInstances() {
@@ -33,6 +35,8 @@ import Testing
         store.redAt = 90
         store.hiddenAccounts = ["slot-2"]
         store.normalColorHex = "#112233"
+        store.yellowColorHex = "#445566"
+        store.redColorHex = "#778899"
 
         let reloaded = SettingsStore(defaults: defaults)
         #expect(reloaded.showUsageOnBar == false)
@@ -43,6 +47,8 @@ import Testing
         #expect(reloaded.redAt == 90)
         #expect(reloaded.hiddenAccounts == ["slot-2"])
         #expect(reloaded.normalColorHex == "#112233")
+        #expect(reloaded.yellowColorHex == "#445566")
+        #expect(reloaded.redColorHex == "#778899")
     }
 
     @Test func unknownDisplayStyleFallsBackToFull() {


### PR DESCRIPTION
## Summary
- PR #5 made the "normal" (green) usage color configurable but left yellow/red hardcoded system alert colors — this extends the same pattern to all three levels.
- Adds `yellowColorHex`/`redColorHex` to `SettingsStore` (defaults `#FFCC00`/`#FF3B30` = `NSColor.systemYellow`/`.systemRed`'s sRGB hex, so existing installs render unchanged) and two more `ColorPicker`s in Settings → Thresholds, reordered so each slider is immediately followed by its color picker (normal picker first, then yellow slider + picker, then red slider + picker, then the threshold-order warning).
- Threads `yellowColor`/`redColor` through `LabelComposite`, `MenuBarLabelView`, and the popover's `AccountsSection` → `AccountRow` → `UsageBar` chain, replacing the hardcoded `.systemYellow`/`.systemRed`/`.yellow`/`.red` in both colored code paths (menu bar percentage text + popover usage bar tint). Percentage text and shimmer/activity text remain untouched (out of scope, same as the normal-color feature).

## Test plan
- [x] `swift test` — 143/143 passing
- [x] `make app` — builds clean
- [ ] Visual: pick custom yellow/red colors in Settings → Thresholds, confirm they show in both the menu bar percentage and popover usage bars
- [ ] Visual: fresh install / no saved prefs renders identically to the old hardcoded yellow/red

🤖 Generated with [Claude Code](https://claude.com/claude-code)
