### PR TITLE
Add CONTRIBUTING.md and CLAUDE.md, polish README for open-source readiness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+Instructions for Claude Code (or any AI coding agent) working in this repo.
+
+## What this is
+
+A native Swift/SwiftUI macOS menu bar app that shows Claude usage and Claude
+Code activity at a glance, built pure-SwiftPM (no Xcode project).
+
+## Architecture: 3 targets
+
+Defined in `Package.swift`:
+
+- **`StatusBarCore`** (library) — all business logic: account discovery,
+  usage fetching/caching, session aggregation, hook event handling, settings
+  persistence, and menu-bar label text/color formatting. This is the *only*
+  target with tests (`Tests/StatusBarCoreTests/`, one file per source file).
+- **`ClaudeStatusBar`** (executable) — the SwiftUI menu bar app. Depends on
+  `StatusBarCore`. Kept as thin as possible: views read from `AppState` and
+  `SettingsStore`, they don't contain logic worth unit-testing on their own.
+- **`ClaudeStatusHook`** (executable) — the `claude-status-hook` binary that
+  Claude Code invokes on session events. Also depends on `StatusBarCore`.
+
+New logic goes in `StatusBarCore` with a matching test file, not in either
+executable — that's what keeps almost the entire app reachable from a fast
+unit test suite despite the two executables having no tests of their own.
+
+## Build and test
+
+CLT-only (Command Line Tools), no Xcode required, macOS 14+, Swift 6 tools
+with `.v5` language mode per target.
+
+```sh
+make build   # swift build (debug)
+make test    # swift test — full StatusBarCoreTests suite
+make app     # dist/ClaudeStatusBar.app (release build + bundle)
+make dmg     # dist/ClaudeStatusBar.dmg
+```
+
+`swift-testing` is pinned at `exact: "0.12.0"` in `Package.swift` rather than
+tracking latest — this is a CLT-only environment with no Xcode to manage
+toolchain/package version drift, so the pin keeps `swift test` reproducible
+across machines and CI. Only the `@Test`/`@Suite`/`#expect`/`#require` API
+available at that version is usable — don't reach for newer swift-testing
+features (e.g. exit tests, custom traits) when writing tests here.
+
+## Non-obvious constraints worth knowing before you touch this code
+
+- **`LabelComposite` bakes the whole menu bar label into one `NSImage`.**
+  `MenuBarExtra` flattens its `label` closure into the status button's single
+  image slot plus title — only the first `Image` survives and it always
+  precedes any text. A multi-view `HStack` can't express text-first ordering
+  or keep the icon once the activity text is itself an image (the shimmer
+  effect). `LabelComposite.image(...)` composites icon + activity text +
+  usage text into one image explicitly instead of fighting that constraint.
+- **`NSApp` is `nil` during `ClaudeStatusBarApp.init()`.** It's too early in
+  the SwiftUI `App` lifecycle; `NSApplication.shared` creates the app object
+  on first access, which is why `init()` calls
+  `NSApplication.shared.setActivationPolicy(.accessory)` rather than
+  `NSApp?.setActivationPolicy(...)`.
+- **`AppState`'s ticker is a plain `Task` loop, not a `TimelineView`.** A
+  periodic `TimelineView` inside the `MenuBarExtra` label re-anchors its
+  schedule to `.now` on every label re-render, so the first scheduled entry
+  is always already due — the main thread spins at 100% CPU and the status
+  item never finishes appearing (observed on macOS 26). `AppState.tick`
+  advances on a `Task.sleep` loop instead, throttled to 33ms (30fps) while
+  activity text needs shimmer frames on the bar, or 1Hz for icon-only/compact
+  styles where nothing sub-second is visible.
+- **The hook binary must never fail Claude Code.** `ClaudeStatusHook`'s
+  `main.swift` swallows every error into a silent `exit(0)` — the hook is
+  fire-and-forget from Claude Code's perspective and must never block or
+  corrupt a session.
+- **OAuth tokens are read from disk only at request time**, kept in a local
+  variable, and never logged, cached, or written elsewhere (`AppState.token`).
+
+## Workflow
+
+Feature branch → PR into `main` → CI (`swift test` + hook integration test,
+see `.github/workflows/ci.yml`) must pass → owner review and merge. Never
+push directly to `main`.
+
+See `CONTRIBUTING.md` for the human-facing contribution guide (test
+expectations, code style, where to report bugs).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+Thanks for considering a contribution to Claude Status Bar. This is a small,
+personal open-source project — the process is lightweight on purpose.
+
+## Build and test
+
+See the [Build from source](README.md#build-from-source) section of the
+README for prerequisites and the `make build` / `make test` / `make app` /
+`make dmg` targets. CI runs `swift test` (same as `make test`) plus the hook
+integration test (`make hook-test`) on every PR — run both locally before you
+open one.
+
+## Tests are expected
+
+This codebase is developed test-first, and the existing suite in
+`Tests/StatusBarCoreTests/` (one file per source file being tested, e.g.
+`SettingsStore.swift` → `SettingsStoreTests.swift`) is the pattern to follow:
+
+- Use [swift-testing](https://github.com/apple/swift-testing), not XCTest —
+  `@Suite`/`@Test` and `#expect`/`#require`. The package pins
+  `swift-testing` at `exact: "0.12.0"`, so stick to the `@Test`/`@Suite`/
+  `#expect`/`#require` surface available at that version; don't reach for
+  newer swift-testing API.
+- New logic belongs in `StatusBarCore` (the tested library target) with a
+  matching test file, not in the `ClaudeStatusBar` or `ClaudeStatusHook`
+  executables — those two stay thin UI/CLI shells so almost everything is
+  reachable from a unit test.
+- Add a failing test for the behavior you're changing before you write the
+  fix/feature, then make it pass. PRs that add behavior with no matching
+  test will be asked to add one.
+
+## Workflow
+
+1. Fork or branch, then work on a feature branch (this repo's history is
+   entirely `feat/...`/`fix/...`/`docs/...` branches merged via PR — there
+   are no direct commits to `main`).
+2. Open a PR into `main`. CI (`swift test` + the hook integration test) must
+   pass before merge.
+3. Keep PRs focused — one feature or fix per PR is easier to review than a
+   bundle of unrelated changes.
+
+## Code style
+
+- Doc comments (`///`) explain *why*, not *what* — see `LabelComposite.swift`
+  or `SettingsStore.swift` for the house style. A comment earns its place by
+  recording a non-obvious constraint or a decision that isn't visible from
+  reading the code (e.g. why a value is computed a particular way, a gotcha
+  that was hit once and shouldn't be re-hit). Don't restate the signature in
+  prose.
+- Match existing naming and structure in the file you're editing rather than
+  introducing a new convention.
+
+## Reporting bugs / proposing features
+
+Use [GitHub Issues](https://github.com/juzser/claude-status-bar-macos/issues).
+For bugs, include your macOS version and, if relevant, whether you're using
+[cux](https://cux.inulute.com) multi-account mode or the plain
+`~/.claude/.credentials.json` path.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Claude Status Bar for macOS
 
+[![CI](https://github.com/juzser/claude-status-bar-macos/actions/workflows/ci.yml/badge.svg)](https://github.com/juzser/claude-status-bar-macos/actions/workflows/ci.yml)
+
 Native macOS menu bar app showing Claude usage and Claude Code activity at a
 glance. A clean-room Swift port of the idea behind
 [claude-status-bar-kde](https://github.com/vntrungld/claude-status-bar-kde),
@@ -55,6 +57,12 @@ make dmg     # dist/ClaudeStatusBar.dmg
 - The app is not sandboxed (it must read `~/.claude` and `~/.cux`).
 - The hook binary always exits 0 and prints nothing, so it can never block
   or corrupt a Claude Code session.
+
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the
+build/test/PR workflow, and [CLAUDE.md](CLAUDE.md) if you're using Claude
+Code (or another AI coding agent) to work in this repo.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add `CONTRIBUTING.md`: build/test pointers (links to README instead of duplicating), the TDD expectation with this repo's existing swift-testing pattern as the model, branch/PR workflow, observable code-style notes (`///` explains why not what), and where to report bugs.
- Add `CLAUDE.md`: what the project is, the 3-target architecture (`StatusBarCore`/`ClaudeStatusBar`/`ClaudeStatusHook`) and why business logic lives in the tested `StatusBarCore` library, build/test commands, the `swift-testing` `exact: "0.12.0"` pin and why, and the non-obvious architectural gotchas (MenuBarExtra's single-image-slot constraint driving `LabelComposite`, `NSApp` being nil during `App.init()`, the TimelineView re-anchoring bug that's why `AppState`'s ticker is a plain `Task` loop).
- README: add a CI status badge (verified the badge URL resolves) and a short "Contributing" section pointing to both new docs, placed before License. No other restructuring.

No CODE_OF_CONDUCT.md added — judged not warranted for a small personal open-source repo with no foundation/governance model; CONTRIBUTING.md's "be respectful" framing plus GitHub's own reporting tools cover this at the appropriate scale. Happy to add one if you'd rather have it.

## Test plan
- [x] `swift build` — clean (docs-only change, no code touched)
- [x] `swift test` — full suite unaffected
- [x] `make hook-test` — passed, confirms the CONTRIBUTING.md claim about what CI actually runs
- [x] Re-read all three files in full after writing, cross-checked claims (target names, Makefile targets, doc-comment style, hook `main.swift` behavior, `AppState` ticker comment, `ClaudeStatusBarApp.init()` comment) against the actual source