### PR TITLE
Add Background style (Transparent/Light/Dark pill) to menu bar label

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,5 +29,9 @@ let package = Package(
             name: "StatusBarCoreTests",
             dependencies: ["StatusBarCore", .product(name: "Testing", package: "swift-testing")],
             swiftSettings: [.swiftLanguageMode(.v5)]),
+        .testTarget(
+            name: "ClaudeStatusBarTests",
+            dependencies: ["ClaudeStatusBar", "StatusBarCore", .product(name: "Testing", package: "swift-testing")],
+            swiftSettings: [.swiftLanguageMode(.v5)]),
     ]
 )

--- a/Sources/ClaudeStatusBar/ClaudeStatusBarApp.swift
+++ b/Sources/ClaudeStatusBar/ClaudeStatusBarApp.swift
@@ -22,7 +22,8 @@ struct ClaudeStatusBarApp: App {
                              normalColor: NSColor(hex: appState.settings.normalColorHex) ?? .systemGreen,
                              yellowColor: NSColor(hex: appState.settings.yellowColorHex) ?? .systemYellow,
                              redColor: NSColor(hex: appState.settings.redColorHex) ?? .systemRed,
-                             animateText: appState.settings.textAnimationEnabled)
+                             animateText: appState.settings.textAnimationEnabled,
+                             backgroundStyle: appState.settings.backgroundStyle)
                 .onAppear {
                     appState.start()
                     Task { await appState.refreshUsageNow() }

--- a/Sources/ClaudeStatusBar/LabelComposite.swift
+++ b/Sources/ClaudeStatusBar/LabelComposite.swift
@@ -14,7 +14,7 @@ enum LabelComposite {
     static func image(model: MenuBarLabelModel, icon: ClawdIcon,
                       shimmerPhase: Double, dark: Bool, normalColor: NSColor,
                       yellowColor: NSColor, redColor: NSColor,
-                      animateText: Bool) -> NSImage {
+                      animateText: Bool, backgroundStyle: BackgroundStyle = .transparent) -> NSImage {
         let busy = model.state == .thinking || model.state == .tool
         let activity: (image: NSImage, offsetY: CGFloat)? = model.activityText.map { text in
             let baked = (busy && animateText)
@@ -41,9 +41,21 @@ enum LabelComposite {
 
         let totalWidth = parts.map(\.image.size.width).reduce(0, +)
             + spacing * CGFloat(parts.count - 1)
-        let size = NSSize(width: totalWidth, height: height)
+        let pillPadding: CGFloat = 6
+        let canvasWidth = backgroundStyle == .transparent ? totalWidth : totalWidth + pillPadding * 2
+        let partsOriginX: CGFloat = backgroundStyle == .transparent ? 0 : pillPadding
+        let size = NSSize(width: canvasWidth, height: height)
         return NSImage(size: size, flipped: false) { _ in
-            var x: CGFloat = 0
+            if let (fill, stroke) = pillColors(for: backgroundStyle) {
+                let pillRect = NSRect(x: 0, y: 0, width: canvasWidth, height: height)
+                let pillPath = NSBezierPath(roundedRect: pillRect, xRadius: height / 2, yRadius: height / 2)
+                fill.setFill()
+                pillPath.fill()
+                stroke.setStroke()
+                pillPath.lineWidth = 0.5
+                pillPath.stroke()
+            }
+            var x: CGFloat = partsOriginX
             for part in parts {
                 // Canvas is y-up; offsetY was measured in y-down (visual)
                 // terms, so subtract it to nudge the artwork toward center.
@@ -54,6 +66,18 @@ enum LabelComposite {
                 x += part.image.size.width + spacing
             }
             return true
+        }
+    }
+
+    /// Fixed reference colors approximating NSColor.windowBackgroundColor
+    /// under each appearance — same "bake a known system color's sRGB hex"
+    /// convention as normalColorHex/yellowColorHex/redColorHex. nil means no
+    /// pill is drawn (.transparent), preserving pre-feature output exactly.
+    private static func pillColors(for style: BackgroundStyle) -> (fill: NSColor, stroke: NSColor)? {
+        switch style {
+        case .transparent: return nil
+        case .light: return (NSColor(hex: "#E5E5E5") ?? .white, NSColor(hex: "#C7C7C7") ?? .lightGray)
+        case .dark: return (NSColor(hex: "#3A3A3C") ?? .black, NSColor(hex: "#545456") ?? .darkGray)
         }
     }
 

--- a/Sources/ClaudeStatusBar/MenuBarLabelView.swift
+++ b/Sources/ClaudeStatusBar/MenuBarLabelView.swift
@@ -10,6 +10,7 @@ struct MenuBarLabelView: View {
     let yellowColor: NSColor
     let redColor: NSColor
     let animateText: Bool
+    let backgroundStyle: StatusBarCore.BackgroundStyle = .transparent
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
@@ -19,11 +20,28 @@ struct MenuBarLabelView: View {
         // or keep more than one image.
         Image(nsImage: LabelComposite.image(model: model, icon: icon,
                                             shimmerPhase: shimmerPhase,
-                                            dark: colorScheme == .dark,
+                                            dark: effectiveDark,
                                             normalColor: normalColor,
                                             yellowColor: yellowColor,
                                             redColor: redColor,
-                                            animateText: animateText))
+                                            animateText: animateText,
+                                            backgroundStyle: backgroundStyle))
             .renderingMode(.original)
+    }
+
+    private var effectiveDark: Bool {
+        Self.effectiveDark(backgroundStyle: backgroundStyle, colorScheme: colorScheme)
+    }
+
+    /// A Light background always pairs with dark content and a Dark
+    /// background always pairs with light content, regardless of system
+    /// appearance; only Transparent follows colorScheme. Static and pure so
+    /// it's testable without constructing a SwiftUI environment.
+    static func effectiveDark(backgroundStyle: StatusBarCore.BackgroundStyle, colorScheme: ColorScheme) -> Bool {
+        switch backgroundStyle {
+        case .transparent: colorScheme == .dark
+        case .light: false
+        case .dark: true
+        }
     }
 }

--- a/Sources/ClaudeStatusBar/MenuBarLabelView.swift
+++ b/Sources/ClaudeStatusBar/MenuBarLabelView.swift
@@ -10,7 +10,7 @@ struct MenuBarLabelView: View {
     let yellowColor: NSColor
     let redColor: NSColor
     let animateText: Bool
-    let backgroundStyle: StatusBarCore.BackgroundStyle = .transparent
+    var backgroundStyle: StatusBarCore.BackgroundStyle = .transparent
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {

--- a/Sources/ClaudeStatusBar/SettingsView.swift
+++ b/Sources/ClaudeStatusBar/SettingsView.swift
@@ -53,6 +53,12 @@ private struct GeneralTab: View {
                 Text("Full — 🦀 Working · 3s  5h 71% · 7d 29%").tag(DisplayStyle.full)
             }
             .pickerStyle(.radioGroup)
+            Picker("Background", selection: $settings.backgroundStyle) {
+                Text("Transparent").tag(StatusBarCore.BackgroundStyle.transparent)
+                Text("Light").tag(StatusBarCore.BackgroundStyle.light)
+                Text("Dark").tag(StatusBarCore.BackgroundStyle.dark)
+            }
+            .pickerStyle(.segmented)
             Picker("Message style", selection: $settings.messageStyleId) {
                 ForEach(MessageStyles.all) { style in
                     Text(style.name).tag(style.id)

--- a/Sources/StatusBarCore/Display/MenuBarText.swift
+++ b/Sources/StatusBarCore/Display/MenuBarText.swift
@@ -4,6 +4,10 @@ public enum DisplayStyle: String, CaseIterable, Sendable {
     case iconOnly, compact, percent, textFirst, full
 }
 
+public enum BackgroundStyle: String, CaseIterable, Sendable {
+    case transparent, light, dark
+}
+
 public struct MenuBarLabelModel: Equatable, Sendable {
     public let state: SessionState
     public let activityText: String?

--- a/Sources/StatusBarCore/Settings/SettingsStore.swift
+++ b/Sources/StatusBarCore/Settings/SettingsStore.swift
@@ -52,10 +52,18 @@ public final class SettingsStore {
     public var textAnimationEnabled: Bool {
         didSet { defaults.set(textAnimationEnabled, forKey: "textAnimationEnabled") }
     }
+    public var backgroundStyleRaw: String {
+        didSet { defaults.set(backgroundStyleRaw, forKey: "backgroundStyleRaw") }
+    }
 
     public var displayStyle: DisplayStyle {
         get { DisplayStyle(rawValue: displayStyleRaw) ?? .full }
         set { displayStyleRaw = newValue.rawValue }
+    }
+
+    public var backgroundStyle: BackgroundStyle {
+        get { BackgroundStyle(rawValue: backgroundStyleRaw) ?? .transparent }
+        set { backgroundStyleRaw = newValue.rawValue }
     }
 
     /// Total: an unknown persisted id falls back to Classic (never crashes,
@@ -78,5 +86,6 @@ public final class SettingsStore {
         yellowColorHex = defaults.string(forKey: "yellowColorHex") ?? "#FFCC00"
         redColorHex = defaults.string(forKey: "redColorHex") ?? "#FF3B30"
         textAnimationEnabled = defaults.object(forKey: "textAnimationEnabled") as? Bool ?? true
+        backgroundStyleRaw = defaults.string(forKey: "backgroundStyleRaw") ?? BackgroundStyle.transparent.rawValue
     }
 }

--- a/Tests/ClaudeStatusBarTests/LabelCompositeTests.swift
+++ b/Tests/ClaudeStatusBarTests/LabelCompositeTests.swift
@@ -1,0 +1,41 @@
+import AppKit
+import Testing
+@testable import ClaudeStatusBar
+@testable import StatusBarCore
+
+private let fixtureModel = MenuBarLabelModel(
+    state: .thinking, activityText: "Working · 3s",
+    usageText: "5h 71% · 7d 29%", fiveHourLevel: .green,
+    sevenDayLevel: .green, usageLevel: .green, textLeading: false)
+
+private func image(backgroundStyle: BackgroundStyle) -> NSImage {
+    LabelComposite.image(model: fixtureModel, icon: .thinking, shimmerPhase: 0,
+                         dark: false, normalColor: .systemGreen,
+                         yellowColor: .systemYellow, redColor: .systemRed,
+                         animateText: false, backgroundStyle: backgroundStyle)
+}
+
+// LabelComposite.frameCache/imageCache are static, non-thread-safe caches —
+// fine in production (always touched from the main thread), but concurrent
+// @Test execution races on them. Same fix as UsageClientTests' .serialized.
+@Suite(.serialized) struct LabelCompositeBackgroundTests {
+    @Test func transparentSizeMatchesPreFeatureBaseline() {
+        let size = image(backgroundStyle: .transparent).size
+        #expect(size.width == 210.0)
+        #expect(size.height == 24.0)
+    }
+
+    @Test func lightAddsExactlyTwelvePointsOfWidth() {
+        let transparent = image(backgroundStyle: .transparent).size
+        let light = image(backgroundStyle: .light).size
+        #expect(light.width == transparent.width + 12)
+        #expect(light.height == transparent.height)
+    }
+
+    @Test func darkAddsExactlyTwelvePointsOfWidth() {
+        let transparent = image(backgroundStyle: .transparent).size
+        let dark = image(backgroundStyle: .dark).size
+        #expect(dark.width == transparent.width + 12)
+        #expect(dark.height == transparent.height)
+    }
+}

--- a/Tests/ClaudeStatusBarTests/MenuBarLabelViewTests.swift
+++ b/Tests/ClaudeStatusBarTests/MenuBarLabelViewTests.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+import Testing
+@testable import ClaudeStatusBar
+import StatusBarCore
+
+@Suite struct MenuBarLabelViewEffectiveDarkTests {
+    @Test func transparentFollowsColorScheme() {
+        #expect(MenuBarLabelView.effectiveDark(backgroundStyle: .transparent, colorScheme: .light) == false)
+        #expect(MenuBarLabelView.effectiveDark(backgroundStyle: .transparent, colorScheme: .dark) == true)
+    }
+
+    @Test func lightForcesLightContentRegardlessOfColorScheme() {
+        #expect(MenuBarLabelView.effectiveDark(backgroundStyle: .light, colorScheme: .light) == false)
+        #expect(MenuBarLabelView.effectiveDark(backgroundStyle: .light, colorScheme: .dark) == false)
+    }
+
+    @Test func darkForcesDarkContentRegardlessOfColorScheme() {
+        #expect(MenuBarLabelView.effectiveDark(backgroundStyle: .dark, colorScheme: .light) == true)
+        #expect(MenuBarLabelView.effectiveDark(backgroundStyle: .dark, colorScheme: .dark) == true)
+    }
+}

--- a/Tests/StatusBarCoreTests/MenuBarTextTests.swift
+++ b/Tests/StatusBarCoreTests/MenuBarTextTests.swift
@@ -221,3 +221,21 @@ private func usage(five: Double, seven: Double) -> AccountUsageState {
         #expect(cycler.next(from: ThinkingVerbs.all) == first)
     }
 }
+
+@Suite struct BackgroundStyleTests {
+    @Test func hasExactlyThreeCases() {
+        #expect(BackgroundStyle.allCases.count == 3)
+    }
+
+    @Test func rawValuesRoundTrip() {
+        for style in BackgroundStyle.allCases {
+            #expect(BackgroundStyle(rawValue: style.rawValue) == style)
+        }
+    }
+
+    @Test func rawValuesMatchCaseNames() {
+        #expect(BackgroundStyle.transparent.rawValue == "transparent")
+        #expect(BackgroundStyle.light.rawValue == "light")
+        #expect(BackgroundStyle.dark.rawValue == "dark")
+    }
+}

--- a/Tests/StatusBarCoreTests/SettingsStoreTests.swift
+++ b/Tests/StatusBarCoreTests/SettingsStoreTests.swift
@@ -23,6 +23,7 @@ import Testing
         #expect(store.yellowColorHex == "#FFCC00")
         #expect(store.redColorHex == "#FF3B30")
         #expect(store.textAnimationEnabled == true)
+        #expect(store.backgroundStyle == .transparent)
     }
 
     @Test func persistsAcrossInstances() {
@@ -39,6 +40,7 @@ import Testing
         store.yellowColorHex = "#445566"
         store.redColorHex = "#778899"
         store.textAnimationEnabled = false
+        store.backgroundStyle = .dark
 
         let reloaded = SettingsStore(defaults: defaults)
         #expect(reloaded.showUsageOnBar == false)
@@ -52,12 +54,19 @@ import Testing
         #expect(reloaded.yellowColorHex == "#445566")
         #expect(reloaded.redColorHex == "#778899")
         #expect(reloaded.textAnimationEnabled == false)
+        #expect(reloaded.backgroundStyle == .dark)
     }
 
     @Test func unknownDisplayStyleFallsBackToFull() {
         let defaults = makeDefaults()
         defaults.set("hologram", forKey: "displayStyleRaw")
         #expect(SettingsStore(defaults: defaults).displayStyle == .full)
+    }
+
+    @Test func unknownBackgroundStyleFallsBackToTransparent() {
+        let defaults = makeDefaults()
+        defaults.set("neon", forKey: "backgroundStyleRaw")
+        #expect(SettingsStore(defaults: defaults).backgroundStyle == .transparent)
     }
 
     @Test func messageStyleDefaultsToClassic() {

--- a/docs/superpowers/plans/2026-07-13-background-style-plan.md
+++ b/docs/superpowers/plans/2026-07-13-background-style-plan.md
@@ -1,0 +1,561 @@
+# Background Style Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user pick a background behind the composited menu bar label — Transparent (default, today's behavior), Light, or Dark — via a new picker in Settings → General.
+
+**Architecture:** A new `BackgroundStyle` enum (mirrors the existing `DisplayStyle` pattern) flows from a persisted `SettingsStore` property, through `MenuBarLabelView` (which also derives `effectiveDark` — the content-color override), into `LabelComposite.image`, which draws a capsule pill behind the composited label parts when the style isn't `.transparent`.
+
+**Tech Stack:** Swift 6.0 (tools version), AppKit (`NSBezierPath`, `NSImage`), SwiftUI, swift-testing 0.12.0 (exact pin).
+
+## Global Constraints
+
+- `swift-tools-version: 6.0` — already set in `Package.swift`, do not change.
+- swift-testing is pinned to **exact** `0.12.0` — only `@Test`, `@Suite`, `#expect`, `#require` are available. No newer swift-testing APIs.
+- `BackgroundStyle` cases: `transparent`, `light`, `dark` (in that order), backed by `String` raw values matching the case names, `CaseIterable`, `Sendable`.
+- `.transparent` output from `LabelComposite.image` must stay **byte-identical** in size to pre-feature behavior — verified by a pinned regression test, not a relative comparison.
+- Pill padding: `CGFloat = 6`, horizontal only, each side. Canvas height never changes (`LabelComposite.height == 24`).
+- Capsule radius = `height / 2` (i.e. `12`), via `NSBezierPath(roundedRect:xRadius:yRadius:)`.
+- Fixed color constants (exact, no user configuration): light fill `#E5E5E5` / stroke `#C7C7C7`; dark fill `#3A3A3C` / stroke `#545456`. Stroke width `0.5pt`.
+- `backgroundStyleRaw` UserDefaults key, default `"transparent"`; unknown persisted value falls back to `.transparent` via `?? .transparent` (never crashes, never rewrites the fallback back to defaults) — same convention as `displayStyleRaw`/`displayStyle`.
+- Light/Dark background content color is **independent of system `colorScheme`**: Light always forces dark (black-ish) content, Dark always forces light (white-ish) content; only Transparent follows `colorScheme`.
+
+---
+
+### Task 1: `BackgroundStyle` enum
+
+**Files:**
+- Modify: `Sources/StatusBarCore/Display/MenuBarText.swift`
+- Test: `Tests/StatusBarCoreTests/MenuBarTextTests.swift`
+
+**Interfaces:**
+- Produces: `public enum BackgroundStyle: String, CaseIterable, Sendable { case transparent, light, dark }` — consumed by Task 2 (`SettingsStore`), Task 3 (`LabelComposite`), Task 4 (`MenuBarLabelView`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add this suite to the end of `Tests/StatusBarCoreTests/MenuBarTextTests.swift`:
+
+```swift
+@Suite struct BackgroundStyleTests {
+    @Test func hasExactlyThreeCases() {
+        #expect(BackgroundStyle.allCases.count == 3)
+    }
+
+    @Test func rawValuesRoundTrip() {
+        for style in BackgroundStyle.allCases {
+            #expect(BackgroundStyle(rawValue: style.rawValue) == style)
+        }
+    }
+
+    @Test func rawValuesMatchCaseNames() {
+        #expect(BackgroundStyle.transparent.rawValue == "transparent")
+        #expect(BackgroundStyle.light.rawValue == "light")
+        #expect(BackgroundStyle.dark.rawValue == "dark")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --filter BackgroundStyleTests`
+Expected: FAIL to build with "cannot find type 'BackgroundStyle' in scope"
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Sources/StatusBarCore/Display/MenuBarText.swift`, add this enum directly below the existing `DisplayStyle` enum (which currently reads `public enum DisplayStyle: String, CaseIterable, Sendable { case iconOnly, compact, percent, textFirst, full }`):
+
+```swift
+public enum BackgroundStyle: String, CaseIterable, Sendable {
+    case transparent, light, dark
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --filter BackgroundStyleTests`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/StatusBarCore/Display/MenuBarText.swift Tests/StatusBarCoreTests/MenuBarTextTests.swift
+git commit -m "feat: add BackgroundStyle enum"
+```
+
+---
+
+### Task 2: `SettingsStore` persistence for `backgroundStyle`
+
+**Files:**
+- Modify: `Sources/StatusBarCore/Settings/SettingsStore.swift`
+- Test: `Tests/StatusBarCoreTests/SettingsStoreTests.swift`
+
+**Interfaces:**
+- Consumes: `BackgroundStyle` (Task 1).
+- Produces: `SettingsStore.backgroundStyleRaw: String` (persisted, didSet writes to `UserDefaults`) and computed `SettingsStore.backgroundStyle: BackgroundStyle` (get/set) — consumed by Task 4 (`MenuBarLabelView`) and Task 5 (`SettingsView`, `ClaudeStatusBarApp`).
+
+- [ ] **Step 1: Write the failing test**
+
+In `Tests/StatusBarCoreTests/SettingsStoreTests.swift`, add `#expect(store.backgroundStyle == .transparent)` to the end of the `defaults()` test body (inside the existing `@Test func defaults()`):
+
+```swift
+    @Test func defaults() {
+        let store = SettingsStore(defaults: makeDefaults())
+        #expect(store.showUsageOnBar == true)
+        #expect(store.showElapsedOnBar == true)
+        #expect(store.displayStyle == .full)
+        #expect(store.pollMinutes == 5)
+        #expect(store.yellowAt == 50)
+        #expect(store.redAt == 80)
+        #expect(store.hiddenAccounts.isEmpty)
+        #expect(store.normalColorHex == "#34C759")
+        #expect(store.yellowColorHex == "#FFCC00")
+        #expect(store.redColorHex == "#FF3B30")
+        #expect(store.textAnimationEnabled == true)
+        #expect(store.backgroundStyle == .transparent)
+    }
+```
+
+Add `store.backgroundStyle = .dark` and the matching reload assertion to `persistsAcrossInstances()`:
+
+```swift
+    @Test func persistsAcrossInstances() {
+        let defaults = makeDefaults()
+        let store = SettingsStore(defaults: defaults)
+        store.showUsageOnBar = false
+        store.showElapsedOnBar = false
+        store.displayStyle = .percent
+        store.pollMinutes = 15
+        store.yellowAt = 40
+        store.redAt = 90
+        store.hiddenAccounts = ["slot-2"]
+        store.normalColorHex = "#112233"
+        store.yellowColorHex = "#445566"
+        store.redColorHex = "#778899"
+        store.textAnimationEnabled = false
+        store.backgroundStyle = .dark
+
+        let reloaded = SettingsStore(defaults: defaults)
+        #expect(reloaded.showUsageOnBar == false)
+        #expect(reloaded.showElapsedOnBar == false)
+        #expect(reloaded.displayStyle == .percent)
+        #expect(reloaded.pollMinutes == 15)
+        #expect(reloaded.yellowAt == 40)
+        #expect(reloaded.redAt == 90)
+        #expect(reloaded.hiddenAccounts == ["slot-2"])
+        #expect(reloaded.normalColorHex == "#112233")
+        #expect(reloaded.yellowColorHex == "#445566")
+        #expect(reloaded.redColorHex == "#778899")
+        #expect(reloaded.textAnimationEnabled == false)
+        #expect(reloaded.backgroundStyle == .dark)
+    }
+```
+
+Add a new test function directly after `unknownDisplayStyleFallsBackToFull()`:
+
+```swift
+    @Test func unknownBackgroundStyleFallsBackToTransparent() {
+        let defaults = makeDefaults()
+        defaults.set("neon", forKey: "backgroundStyleRaw")
+        #expect(SettingsStore(defaults: defaults).backgroundStyle == .transparent)
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --filter SettingsStoreTests`
+Expected: FAIL to build with "value of type 'SettingsStore' has no member 'backgroundStyle'"
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Sources/StatusBarCore/Settings/SettingsStore.swift`, add a persisted property directly below `textAnimationEnabled`:
+
+```swift
+    public var backgroundStyleRaw: String {
+        didSet { defaults.set(backgroundStyleRaw, forKey: "backgroundStyleRaw") }
+    }
+```
+
+Add the computed property directly below `displayStyle`:
+
+```swift
+    public var backgroundStyle: BackgroundStyle {
+        get { BackgroundStyle(rawValue: backgroundStyleRaw) ?? .transparent }
+        set { backgroundStyleRaw = newValue.rawValue }
+    }
+```
+
+In `init(defaults:)`, add this line directly below the `textAnimationEnabled = ...` line:
+
+```swift
+        backgroundStyleRaw = defaults.string(forKey: "backgroundStyleRaw") ?? BackgroundStyle.transparent.rawValue
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --filter SettingsStoreTests`
+Expected: PASS (all `SettingsStoreTests` suite tests, including the 3 new/modified ones)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/StatusBarCore/Settings/SettingsStore.swift Tests/StatusBarCoreTests/SettingsStoreTests.swift
+git commit -m "feat: persist backgroundStyle in SettingsStore"
+```
+
+---
+
+### Task 3: `ClaudeStatusBarTests` target + `LabelComposite` pill background
+
+**Files:**
+- Modify: `Package.swift`
+- Modify: `Sources/ClaudeStatusBar/LabelComposite.swift`
+- Create: `Tests/ClaudeStatusBarTests/LabelCompositeTests.swift`
+
+**Interfaces:**
+- Consumes: `BackgroundStyle` (Task 1); `NSColor(hex:)` from `Sources/ClaudeStatusBar/ColorHex.swift` (existing, same target).
+- Produces: `LabelComposite.image(model:icon:shimmerPhase:dark:normalColor:yellowColor:redColor:animateText:backgroundStyle:) -> NSImage` (new `backgroundStyle: BackgroundStyle` parameter, appended last) — consumed by Task 4 (`MenuBarLabelView`). Establishes the `ClaudeStatusBarTests` test target, reused by Task 4's tests.
+
+**Note on the new test target:** the `ClaudeStatusBar` product is an `.executableTarget`; `testTarget(name: "ClaudeStatusBarTests", dependencies: ["ClaudeStatusBar", ...])` can `@testable import ClaudeStatusBar` from it exactly like `StatusBarCoreTests` does for `StatusBarCore` — this is a supported SwiftPM pattern, not a workaround.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/ClaudeStatusBarTests/LabelCompositeTests.swift`:
+
+```swift
+import AppKit
+import Testing
+@testable import ClaudeStatusBar
+@testable import StatusBarCore
+
+private let fixtureModel = MenuBarLabelModel(
+    state: .thinking, activityText: "Working · 3s",
+    usageText: "5h 71% · 7d 29%", fiveHourLevel: .green,
+    sevenDayLevel: .green, usageLevel: .green, textLeading: false)
+
+private func image(backgroundStyle: BackgroundStyle) -> NSImage {
+    LabelComposite.image(model: fixtureModel, icon: .thinking, shimmerPhase: 0,
+                         dark: false, normalColor: .systemGreen,
+                         yellowColor: .systemYellow, redColor: .systemRed,
+                         animateText: false, backgroundStyle: backgroundStyle)
+}
+
+@Suite struct LabelCompositeBackgroundTests {
+    @Test func transparentSizeMatchesPreFeatureBaseline() {
+        let size = image(backgroundStyle: .transparent).size
+        #expect(size.width == 210.0)
+        #expect(size.height == 24.0)
+    }
+
+    @Test func lightAddsExactlyTwelvePointsOfWidth() {
+        let transparent = image(backgroundStyle: .transparent).size
+        let light = image(backgroundStyle: .light).size
+        #expect(light.width == transparent.width + 12)
+        #expect(light.height == transparent.height)
+    }
+
+    @Test func darkAddsExactlyTwelvePointsOfWidth() {
+        let transparent = image(backgroundStyle: .transparent).size
+        let dark = image(backgroundStyle: .dark).size
+        #expect(dark.width == transparent.width + 12)
+        #expect(dark.height == transparent.height)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --filter LabelCompositeBackgroundTests`
+Expected: FAIL to build — no `ClaudeStatusBarTests` target exists yet, and `LabelComposite.image` has no `backgroundStyle` parameter.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Package.swift`, add a new test target as the last entry in the `targets:` array (directly after the existing `StatusBarCoreTests` target):
+
+```swift
+        .testTarget(
+            name: "ClaudeStatusBarTests",
+            dependencies: ["ClaudeStatusBar", "StatusBarCore", .product(name: "Testing", package: "swift-testing")],
+            swiftSettings: [.swiftLanguageMode(.v5)]),
+```
+
+The full `targets:` array becomes:
+
+```swift
+    targets: [
+        .target(
+            name: "StatusBarCore",
+            swiftSettings: [.swiftLanguageMode(.v5)]),
+        .executableTarget(
+            name: "ClaudeStatusBar",
+            dependencies: ["StatusBarCore"],
+            resources: [.copy("Resources/clawd")],
+            swiftSettings: [.swiftLanguageMode(.v5)]),
+        .executableTarget(
+            name: "ClaudeStatusHook",
+            dependencies: ["StatusBarCore"],
+            swiftSettings: [.swiftLanguageMode(.v5)]),
+        .testTarget(
+            name: "StatusBarCoreTests",
+            dependencies: ["StatusBarCore", .product(name: "Testing", package: "swift-testing")],
+            swiftSettings: [.swiftLanguageMode(.v5)]),
+        .testTarget(
+            name: "ClaudeStatusBarTests",
+            dependencies: ["ClaudeStatusBar", "StatusBarCore", .product(name: "Testing", package: "swift-testing")],
+            swiftSettings: [.swiftLanguageMode(.v5)]),
+    ]
+```
+
+In `Sources/ClaudeStatusBar/LabelComposite.swift`, change the `image` function signature (add `backgroundStyle: BackgroundStyle` as the last parameter):
+
+```swift
+    static func image(model: MenuBarLabelModel, icon: ClawdIcon,
+                      shimmerPhase: Double, dark: Bool, normalColor: NSColor,
+                      yellowColor: NSColor, redColor: NSColor,
+                      animateText: Bool, backgroundStyle: BackgroundStyle) -> NSImage {
+```
+
+Replace the tail of the function — from `guard !parts.isEmpty else { ... }` through the closing `}` of the `NSImage(size:flipped:)` closure — with:
+
+```swift
+        guard !parts.isEmpty else { return NSImage(size: NSSize(width: 1, height: height)) }
+
+        let totalWidth = parts.map(\.image.size.width).reduce(0, +)
+            + spacing * CGFloat(parts.count - 1)
+        let pillPadding: CGFloat = 6
+        let canvasWidth = backgroundStyle == .transparent ? totalWidth : totalWidth + pillPadding * 2
+        let partsOriginX: CGFloat = backgroundStyle == .transparent ? 0 : pillPadding
+        let size = NSSize(width: canvasWidth, height: height)
+        return NSImage(size: size, flipped: false) { _ in
+            if let (fill, stroke) = pillColors(for: backgroundStyle) {
+                let pillRect = NSRect(x: 0, y: 0, width: canvasWidth, height: height)
+                let pillPath = NSBezierPath(roundedRect: pillRect, xRadius: height / 2, yRadius: height / 2)
+                fill.setFill()
+                pillPath.fill()
+                stroke.setStroke()
+                pillPath.lineWidth = 0.5
+                pillPath.stroke()
+            }
+            var x: CGFloat = partsOriginX
+            for part in parts {
+                // Canvas is y-up; offsetY was measured in y-down (visual)
+                // terms, so subtract it to nudge the artwork toward center.
+                let y = (height - part.image.size.height) / 2 - part.offsetY
+                part.image.draw(in: NSRect(x: x, y: y,
+                                           width: part.image.size.width,
+                                           height: part.image.size.height))
+                x += part.image.size.width + spacing
+            }
+            return true
+        }
+    }
+
+    /// Fixed reference colors approximating NSColor.windowBackgroundColor
+    /// under each appearance — same "bake a known system color's sRGB hex"
+    /// convention as normalColorHex/yellowColorHex/redColorHex. nil means no
+    /// pill is drawn (.transparent), preserving pre-feature output exactly.
+    private static func pillColors(for style: BackgroundStyle) -> (fill: NSColor, stroke: NSColor)? {
+        switch style {
+        case .transparent: return nil
+        case .light: return (NSColor(hex: "#E5E5E5") ?? .white, NSColor(hex: "#C7C7C7") ?? .lightGray)
+        case .dark: return (NSColor(hex: "#3A3A3C") ?? .black, NSColor(hex: "#545456") ?? .darkGray)
+        }
+    }
+```
+
+(This adds the `pillColors(for:)` helper as a new private static method and closes the `image` function as before — the rest of `LabelComposite.swift` below `image` is unchanged.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --filter LabelCompositeBackgroundTests`
+Expected: PASS (3 tests)
+
+Then run the full suite once to confirm the new target didn't break anything else: `swift test`
+Expected: all tests PASS (existing `StatusBarCoreTests` target is untouched by this task).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Package.swift Sources/ClaudeStatusBar/LabelComposite.swift Tests/ClaudeStatusBarTests/LabelCompositeTests.swift
+git commit -m "feat: draw background pill in LabelComposite"
+```
+
+---
+
+### Task 4: `MenuBarLabelView.effectiveDark` + `backgroundStyle` threading
+
+**Files:**
+- Modify: `Sources/ClaudeStatusBar/MenuBarLabelView.swift`
+- Create: `Tests/ClaudeStatusBarTests/MenuBarLabelViewTests.swift`
+
+**Interfaces:**
+- Consumes: `BackgroundStyle` (Task 1); `LabelComposite.image(...)` with `backgroundStyle:` parameter (Task 3); `ClaudeStatusBarTests` target (Task 3).
+- Produces: `MenuBarLabelView.effectiveDark(backgroundStyle:colorScheme:) -> Bool` (static, pure — testable without rendering) and `MenuBarLabelView.backgroundStyle: BackgroundStyle` (instance property) — consumed by Task 5 (`ClaudeStatusBarApp.swift` call site).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/ClaudeStatusBarTests/MenuBarLabelViewTests.swift`:
+
+```swift
+import SwiftUI
+import Testing
+@testable import ClaudeStatusBar
+import StatusBarCore
+
+@Suite struct MenuBarLabelViewEffectiveDarkTests {
+    @Test func transparentFollowsColorScheme() {
+        #expect(MenuBarLabelView.effectiveDark(backgroundStyle: .transparent, colorScheme: .light) == false)
+        #expect(MenuBarLabelView.effectiveDark(backgroundStyle: .transparent, colorScheme: .dark) == true)
+    }
+
+    @Test func lightForcesLightContentRegardlessOfColorScheme() {
+        #expect(MenuBarLabelView.effectiveDark(backgroundStyle: .light, colorScheme: .light) == false)
+        #expect(MenuBarLabelView.effectiveDark(backgroundStyle: .light, colorScheme: .dark) == false)
+    }
+
+    @Test func darkForcesDarkContentRegardlessOfColorScheme() {
+        #expect(MenuBarLabelView.effectiveDark(backgroundStyle: .dark, colorScheme: .light) == true)
+        #expect(MenuBarLabelView.effectiveDark(backgroundStyle: .dark, colorScheme: .dark) == true)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --filter MenuBarLabelViewEffectiveDarkTests`
+Expected: FAIL to build with "type 'MenuBarLabelView' has no member 'effectiveDark'"
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the full contents of `Sources/ClaudeStatusBar/MenuBarLabelView.swift` with:
+
+```swift
+import AppKit
+import SwiftUI
+import StatusBarCore
+
+struct MenuBarLabelView: View {
+    let model: MenuBarLabelModel
+    let icon: ClawdIcon
+    var shimmerPhase: Double = 0
+    let normalColor: NSColor
+    let yellowColor: NSColor
+    let redColor: NSColor
+    let animateText: Bool
+    let backgroundStyle: BackgroundStyle
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        // The whole label is composited into one NSImage (LabelComposite):
+        // MenuBarExtra flattens its label into the status button's single
+        // image slot + title, so a multi-view HStack cannot control order
+        // or keep more than one image.
+        Image(nsImage: LabelComposite.image(model: model, icon: icon,
+                                            shimmerPhase: shimmerPhase,
+                                            dark: effectiveDark,
+                                            normalColor: normalColor,
+                                            yellowColor: yellowColor,
+                                            redColor: redColor,
+                                            animateText: animateText,
+                                            backgroundStyle: backgroundStyle))
+            .renderingMode(.original)
+    }
+
+    private var effectiveDark: Bool {
+        Self.effectiveDark(backgroundStyle: backgroundStyle, colorScheme: colorScheme)
+    }
+
+    /// A Light background always pairs with dark content and a Dark
+    /// background always pairs with light content, regardless of system
+    /// appearance; only Transparent follows colorScheme. Static and pure so
+    /// it's testable without constructing a SwiftUI environment.
+    static func effectiveDark(backgroundStyle: BackgroundStyle, colorScheme: ColorScheme) -> Bool {
+        switch backgroundStyle {
+        case .transparent: colorScheme == .dark
+        case .light: false
+        case .dark: true
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --filter MenuBarLabelViewEffectiveDarkTests`
+Expected: PASS (3 tests)
+
+Run: `swift build`
+Expected: FAILS — `ClaudeStatusBarApp.swift` calls `MenuBarLabelView(...)` without the new required `backgroundStyle:` argument. This is expected; Task 5 fixes the call site. Confirm the failure is specifically a missing-argument error at that call site (not something else) before moving on.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/ClaudeStatusBar/MenuBarLabelView.swift Tests/ClaudeStatusBarTests/MenuBarLabelViewTests.swift
+git commit -m "feat: derive effectiveDark content color from backgroundStyle"
+```
+
+---
+
+### Task 5: Settings picker + app wiring
+
+**Files:**
+- Modify: `Sources/ClaudeStatusBar/SettingsView.swift`
+- Modify: `Sources/ClaudeStatusBar/ClaudeStatusBarApp.swift`
+
+**Interfaces:**
+- Consumes: `SettingsStore.backgroundStyle` (Task 2); `MenuBarLabelView.backgroundStyle` parameter (Task 4).
+- Produces: nothing further downstream — this is the final task.
+
+- [ ] **Step 1: Wire the picker into `GeneralTab`**
+
+In `Sources/ClaudeStatusBar/SettingsView.swift`, in `GeneralTab.body`, add a new `Picker` directly below the existing `Picker("Display style", ...)` block (which ends with `.pickerStyle(.radioGroup)`) and above `Picker("Message style", ...)`:
+
+```swift
+            Picker("Background", selection: $settings.backgroundStyle) {
+                Text("Transparent").tag(BackgroundStyle.transparent)
+                Text("Light").tag(BackgroundStyle.light)
+                Text("Dark").tag(BackgroundStyle.dark)
+            }
+            .pickerStyle(.segmented)
+```
+
+The surrounding `Form` block in `GeneralTab.body` reads, in order, after this change: `Toggle("Launch at login", ...)`, `Toggle("Show usage on menu bar", ...)`, `Toggle("Show elapsed time on menu bar", ...)`, `Toggle("Animate activity text", ...)`, `Picker("Display style", ...)`, the new `Picker("Background", ...)`, `Picker("Message style", ...)`, `Picker("Usage poll interval", ...)` — no other lines change.
+
+- [ ] **Step 2: Thread `backgroundStyle` into the `MenuBarLabelView` call site**
+
+In `Sources/ClaudeStatusBar/ClaudeStatusBarApp.swift`, add `backgroundStyle: appState.settings.backgroundStyle` as the last argument to the `MenuBarLabelView(...)` call:
+
+```swift
+            MenuBarLabelView(model: appState.labelModel,
+                             icon: StatusIcon.icon(for: appState.display),
+                             shimmerPhase: ShimmerText.phase(at: appState.tick),
+                             normalColor: NSColor(hex: appState.settings.normalColorHex) ?? .systemGreen,
+                             yellowColor: NSColor(hex: appState.settings.yellowColorHex) ?? .systemYellow,
+                             redColor: NSColor(hex: appState.settings.redColorHex) ?? .systemRed,
+                             animateText: appState.settings.textAnimationEnabled,
+                             backgroundStyle: appState.settings.backgroundStyle)
+```
+
+- [ ] **Step 3: Build and run the full test suite**
+
+Run: `swift build`
+Expected: succeeds with no errors.
+
+Run: `swift test`
+Expected: all tests PASS across both `StatusBarCoreTests` and `ClaudeStatusBarTests` — no regressions in any pre-existing test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/ClaudeStatusBar/SettingsView.swift Sources/ClaudeStatusBar/ClaudeStatusBarApp.swift
+git commit -m "feat: add Background picker to Settings and wire it to the menu bar label"
+```
+
+- [ ] **Step 5: Manual smoke check (owner: Ser, not automatable)**
+
+Build and launch the app (`make app` then `open dist/ClaudeStatusBar.app`, or `swift run ClaudeStatusBar` for a quick check), open Settings → General, and confirm:
+- The "Background" segmented picker appears directly below "Display style" with Transparent/Light/Dark options.
+- Switching between all three styles updates the menu bar label within ~1s (existing render cadence), with no crash.
+- Transparent renders pixel-identical to before this feature (no visible pill).
+- Light and Dark pills stay legible against both a light-appearance and a dark-appearance system menu bar.
+- The pill grows/shrinks with activity text length changes (e.g. switching Display style or watching elapsed time tick up) without clipping or overlapping the real menu bar edge.

--- a/docs/superpowers/specs/2026-07-13-background-style-design.md
+++ b/docs/superpowers/specs/2026-07-13-background-style-design.md
@@ -1,0 +1,186 @@
+# Background Style — Design
+
+**Date:** 2026-07-13
+**Status:** Approved pending user spec review
+**Repo:** claude-status-bar-macos (base: main @ fe931ff)
+
+## Goal
+
+Let the user pick a background behind the composited menu bar label —
+**Transparent** (today's behavior, default), **Light**, or **Dark** — so the
+bar can stay legible against busy wallpaper or a translucent menu bar,
+independent of the system's light/dark appearance. The picker lives in
+Settings → General, next to "Display style".
+
+## Background (current pipeline)
+
+- `LabelComposite.image(...)` bakes the entire label — activity text, Clawd
+  icon, usage % — into **one** `NSImage`. This is required: a
+  `MenuBarExtra` label is flattened into the status button's single image
+  slot plus title, so a multi-view `HStack` can neither control part order
+  nor keep more than one image. Compositing sidesteps the slots entirely.
+- `MenuBarLabelView` reads `@Environment(\.colorScheme)` and passes
+  `dark: colorScheme == .dark` into `LabelComposite.image`. `dark` drives
+  content color: `ShimmerText.plain`/`.image` render white text/icon tint
+  when `dark == true`, black when `false` — i.e. `dark` already means
+  "render for a dark background," not "system is in dark mode." Today the
+  two happen to be the same value.
+- The composited image has no background of its own — it draws straight
+  through to the real menu bar, which is why "transparent" is the existing,
+  unnamed default.
+
+## Decisions (from brainstorming)
+
+1. **Scope: a pill behind the whole label.** The background sits behind
+   the entire composited label (icon + activity text + usage %), not
+   behind individual parts. Transparent means no background at all — pixel
+   output identical to pre-feature behavior — and stays the default.
+2. **Content color syncs to the chosen background, not to system
+   appearance.** Light background forces dark content; Dark background
+   forces light content; Transparent keeps today's auto-detect
+   (`colorScheme == .dark`). This reuses the existing `dark:` parameter
+   semantics in `LabelComposite`/`ShimmerText` — no new color-override
+   mechanism needed.
+3. **Shape: full capsule.** Fully rounded (radius = label height / 2),
+   hugging the label's existing 24pt height with **horizontal-only**
+   padding. Never taller than today's label, so it cannot clip against the
+   menu bar's fixed content height.
+4. **Colors: fixed, not user-configurable.** No new `ColorPicker`. Two
+   literal hex constants (one per style), chosen to approximate
+   `NSColor.windowBackgroundColor` under each appearance — same convention
+   `normalColorHex`/`yellowColorHex`/`redColorHex` already use (baking a
+   known system color's sRGB hex rather than resolving it live).
+
+## Architecture
+
+`BackgroundStyle` — new enum alongside `DisplayStyle` in
+`Sources/StatusBarCore/Display/MenuBarText.swift` (no new file; `DisplayStyle`
+already lives there and is this small):
+
+```swift
+public enum BackgroundStyle: String, CaseIterable, Sendable {
+    case transparent, light, dark
+}
+```
+
+Touched components (no other new files):
+
+- **`SettingsStore`** — new persisted property `backgroundStyleRaw: String`
+  (UserDefaults key `backgroundStyleRaw`, default `"transparent"`) +
+  computed `backgroundStyle: BackgroundStyle`, same get/set pattern as
+  `displayStyle`:
+  ```swift
+  public var backgroundStyle: BackgroundStyle {
+      get { BackgroundStyle(rawValue: backgroundStyleRaw) ?? .transparent }
+      set { backgroundStyleRaw = newValue.rawValue }
+  }
+  ```
+- **`MenuBarLabelView`** — gains `let backgroundStyle: BackgroundStyle`. The
+  literal `dark: colorScheme == .dark` passed to `LabelComposite.image` is
+  replaced by a computed property:
+  ```swift
+  private var effectiveDark: Bool {
+      switch backgroundStyle {
+      case .transparent: colorScheme == .dark
+      case .light: false
+      case .dark: true
+      }
+  }
+  ```
+  `effectiveDark` is passed as `dark:`, and `backgroundStyle` is passed as
+  a new parameter, into `LabelComposite.image`.
+- **`LabelComposite.image`** — gains a `backgroundStyle: BackgroundStyle`
+  parameter. Current behavior (compute `parts`, `totalWidth`, draw at
+  origin) is reached unchanged when `backgroundStyle == .transparent` —
+  byte-identical output, verified by regression test. Otherwise, after
+  computing `parts`/`totalWidth` as today:
+  - `pillPadding: CGFloat = 6` (horizontal only, each side; no change to
+    vertical sizing — canvas height stays `height` = 24).
+  - Canvas width becomes `totalWidth + pillPadding * 2`.
+  - Fill a capsule path first —
+    `NSBezierPath(roundedRect: NSRect(x: 0, y: 0, width: canvasWidth, height: height), xRadius: height / 2, yRadius: height / 2)`
+    — with the style's fixed background color, then stroke it at 0.5pt in
+    a slightly higher-contrast tint of the same color (keeps the pill
+    legible when the real menu bar itself is translucent and near the same
+    tone).
+  - Draw `parts` shifted right by `pillPadding` (unchanged inter-part
+    layout otherwise).
+  - Fixed color constants (reference values — confirm visually against a
+    real light/dark menu bar during implementation and adjust if contrast
+    is poor; follow the same "bake a concrete hex, note what it
+    approximates" convention as `normalColorHex`'s doc comment):
+    - light: fill `#E5E5E5`, stroke `#C7C7C7`
+    - dark: fill `#3A3A3C`, stroke `#545456`
+- **`SettingsView.swift` (`GeneralTab`)** — new picker directly below
+  "Display style":
+  ```swift
+  Picker("Background", selection: $settings.backgroundStyle) {
+      Text("Transparent").tag(BackgroundStyle.transparent)
+      Text("Light").tag(BackgroundStyle.light)
+      Text("Dark").tag(BackgroundStyle.dark)
+  }
+  .pickerStyle(.segmented)
+  ```
+- **`ClaudeStatusBarApp.swift`** — threads
+  `backgroundStyle: appState.settings.backgroundStyle` into the
+  `MenuBarLabelView(...)` call site.
+
+Untouched: `ShimmerText`, `StatusIcon`, message styles, threshold colors,
+popover (`PopoverView`/`SessionsSection` keep their own native window
+background — this feature only affects the menu bar label).
+
+## Behavior
+
+- Transparent (default) renders pixel-identical to pre-feature output —
+  same canvas size, same part layout, same `dark` source (`colorScheme`).
+- Switching style takes effect on the next render tick (≤1s, existing
+  cadence) — no re-roll needed (unlike message styles, background doesn't
+  touch any cycling/random state).
+- Pill width tracks content width automatically, same as today's
+  transparent canvas, just wider by `pillPadding * 2`.
+- Light/Dark background modes intentionally override `colorScheme`-driven
+  content color rather than follow it — a Dark background always pairs
+  with light content, regardless of whether the system is in light or dark
+  mode.
+
+## Error handling
+
+- `BackgroundStyle(rawValue:) ?? .transparent`: an unknown persisted value
+  (e.g. a future style removed) falls back to Transparent — never crashes,
+  never rewrites the fallback back to `UserDefaults`. Mirrors the existing
+  `displayStyle` fallback pattern.
+
+## Testing (swift-testing 0.12.0 API: `@Test`/`@Suite`/`#expect`/`#require`)
+
+- **`BackgroundStyle`** — `CaseIterable.allCases.count == 3`; each case's
+  `rawValue` round-trips through `init(rawValue:)`.
+- **`SettingsStore`** — `backgroundStyleRaw` persists and reloads across a
+  fresh `SettingsStore` instance; missing key defaults to `"transparent"`;
+  an unknown persisted raw value resolves to `.transparent` via
+  `backgroundStyle`.
+- **`MenuBarLabelView.effectiveDark`** (pure computed property, testable
+  without rendering) — `.transparent` + light `colorScheme` → `false`;
+  `.transparent` + dark `colorScheme` → `true`; `.light` → `false`
+  regardless of `colorScheme`; `.dark` → `true` regardless of
+  `colorScheme`.
+- **`LabelComposite` regression** — `.transparent` output image size is
+  identical to the pre-feature baseline for a given model/icon combo (no
+  existing test's expected size may change).
+- **`LabelComposite` new cases** — `.light`/`.dark` output image width
+  equals the `.transparent` width for the same model plus exactly
+  `pillPadding * 2`; height is unchanged (still 24).
+- **Manual smoke check** (owner: Ser, same pattern as prior visual-only
+  features): confirm the pill renders correctly and stays legible in both
+  system light and dark menu bars, across all three background styles, as
+  activity text length changes (pill must grow/shrink without clipping or
+  overlapping the real menu bar edge).
+
+## Out of scope
+
+- User-configurable background colors (no new `ColorPicker`).
+- Background shapes other than a full capsule (no rect/rounded-rect
+  option).
+- Applying a background to the popover window.
+- Any interaction with the usage-level text colors (normal/yellow/red) —
+  those stay independent of background style.
+- Blur/vibrancy materials (`NSVisualEffectView`-style) — plain fill only.


### PR DESCRIPTION
## Summary
- Adds a `BackgroundStyle` (Transparent/Light/Dark) setting that draws a rounded pill behind the composited menu bar label; Transparent stays pixel-identical to prior behavior.
- `MenuBarLabelView.effectiveDark` forces label content color for Light/Dark (overriding system colorScheme), leaving Transparent to keep following it.
- New "Background" segmented picker in Settings → General, directly below "Display style".

## Design & plan
- Spec: `docs/superpowers/specs/2026-07-13-background-style-design.md`
- Plan: `docs/superpowers/plans/2026-07-13-background-style-plan.md`
- Implemented via Subagent-Driven Development, 5 tasks, each with a task-level spec+quality review, plus a final whole-branch review.

## Test plan
- [x] `swift test` — 153/153 passing (includes new `LabelCompositeBackgroundTests`, `MenuBarLabelViewEffectiveDarkTests`, `SettingsStoreTests.unknownBackgroundStyleFallsBackToTransparent`)
- [x] Final whole-branch review (opus): Ready to merge — Yes, 0 Critical, 0 Important, 4 non-blocking Minor findings recorded in `.superpowers/sdd/progress.md`
- [ ] Manual smoke check (owner: Ser) — Settings → General → Background picker across all 3 styles, both system appearances

🤖 Generated with SDD (superpowers) via Hans
