### PR TITLE
Remove shimmer diagnostic probes now that FPS is confirmed

### DIFF
--- a/Sources/ClaudeStatusBar/AppState.swift
+++ b/Sources/ClaudeStatusBar/AppState.swift
@@ -1,11 +1,6 @@
 import Foundation
 import Observation
 import StatusBarCore
-import os
-
-// DIAGNOSTIC(shimmer): temporary ticker probe — remove once the
-// "no visible animation" report is resolved.
-private let tickerLog = Logger(subsystem: "ClaudeStatusBar", category: "shimmer")
 
 /// Single source of truth for the UI.
 @Observable @MainActor
@@ -132,8 +127,6 @@ final class AppState {
             tickTask?.cancel()
             tickInterval = interval
             tick = Date()
-            // DIAGNOSTIC(shimmer):
-            tickerLog.info("ticker start interval=\(interval == .seconds(1) ? "1s" : "33ms", privacy: .public) style=\(String(describing: self.displayStyle), privacy: .public) state=\(String(describing: self.display?.state), privacy: .public)")
             tickTask = Task { [weak self] in
                 while !Task.isCancelled {
                     try? await Task.sleep(for: interval)
@@ -141,10 +134,6 @@ final class AppState {
                 }
             }
         } else {
-            if tickTask != nil {
-                // DIAGNOSTIC(shimmer):
-                tickerLog.info("ticker stop")
-            }
             tickTask?.cancel()
             tickTask = nil
         }

--- a/Sources/ClaudeStatusBar/ShimmerText.swift
+++ b/Sources/ClaudeStatusBar/ShimmerText.swift
@@ -1,11 +1,4 @@
 import AppKit
-import os
-
-// DIAGNOSTIC(shimmer): temporary render-rate probe — remove once the
-// "no visible animation" report is resolved.
-private let shimmerLog = Logger(subsystem: "ClaudeStatusBar", category: "shimmer")
-private nonisolated(unsafe) var renderCount = 0
-private nonisolated(unsafe) var lastSampleAt = Date.distantPast
 
 /// Renders the bar's activity text with a left→right shimmer. MenuBarExtra
 /// flattens SwiftUI Text foreground colors to a monochrome template, so the
@@ -64,14 +57,6 @@ enum ShimmerText {
     }
 
     static func image(_ text: String, phase: Double, dark: Bool) -> NSImage {
-        // DIAGNOSTIC(shimmer): sampled ~1/sec; renders-per-second ≈ fps.
-        renderCount += 1
-        let now = Date()
-        if now.timeIntervalSince(lastSampleAt) >= 1 {
-            shimmerLog.info("renders/s=\(renderCount) phase=\(phase, format: .fixed(precision: 3)) text=\(text, privacy: .public)")
-            renderCount = 0
-            lastSampleAt = now
-        }
         let full: NSColor = dark ? .white : .black
         // The dim base must be an opaque gray, not full.withAlphaComponent:
         // sourceAtop of a color onto an alpha-faded copy of itself is a no-op


### PR DESCRIPTION
## Summary
- Removes the temporary `DIAGNOSTIC(shimmer)` probe instrumentation added during the PR #6 FPS-tuning round.
- `Sources/ClaudeStatusBar/ShimmerText.swift`: drops `shimmerLog`, `renderCount`, `lastSampleAt`, the sampled ~1/sec logging block in `image(_:phase:dark:)`, the now-unused `import os`, and the DIAGNOSTIC comments.
- `Sources/ClaudeStatusBar/AppState.swift`: drops `tickerLog`, the ticker start/stop log lines, the now-unused `import os`, and the DIAGNOSTIC comments.
- Pure removal — no behavior change. The shimmer FPS was already visually confirmed after PR #6 merged, so the probes are no longer needed.

## Test plan
- [x] `swift test` — all 143 tests pass
- [x] `make app` — builds and signs `dist/ClaudeStatusBar.app` cleanly

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
