### PR TITLE
Bump version to 0.1.1 for the next release

### DIFF
--- a/Sources/StatusBarCore/StatusBarCore.swift
+++ b/Sources/StatusBarCore/StatusBarCore.swift
@@ -1,3 +1,3 @@
 public enum StatusBarCoreInfo {
-    public static let version = "0.1.0"
+    public static let version = "0.1.1"
 }

--- a/Tests/StatusBarCoreTests/PackageTests.swift
+++ b/Tests/StatusBarCoreTests/PackageTests.swift
@@ -2,5 +2,5 @@ import Testing
 @testable import StatusBarCore
 
 @Test func versionIsSet() {
-    #expect(StatusBarCoreInfo.version == "0.1.0")
+    #expect(StatusBarCoreInfo.version == "0.1.1")
 }

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-VERSION="${VERSION:-0.1.0}"
+VERSION="${VERSION:-0.1.1}"
 APP="dist/ClaudeStatusBar.app"
 BIN=".build/release"
 


### PR DESCRIPTION
Bumps the app version 0.1.0 → 0.1.1 in the three places it lives, ahead of tagging the v0.1.1 release:

- `Sources/StatusBarCore/StatusBarCore.swift` — `StatusBarCoreInfo.version`
- `Tests/StatusBarCoreTests/PackageTests.swift` — the assertion pinning it
- `scripts/make-app.sh` — the `VERSION` default stamped into Info.plist

Since v0.1.0, main picked up #12 (remove shimmer diagnostic probes) and #14 (detailed install guide in README) — patch-level, hence 0.1.1.

143/143 tests pass after the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
