### PR TITLE
Fix usage never showing for cux-managed accounts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,13 @@ features (e.g. exit tests, custom traits) when writing tests here.
   `main.swift` swallows every error into a silent `exit(0)` — the hook is
   fire-and-forget from Claude Code's perspective and must never block or
   corrupt a session.
-- **OAuth tokens are read from disk only at request time**, kept in a local
-  variable, and never logged, cached, or written elsewhere (`AppState.token`).
+- **OAuth tokens are read at request time only**, kept in a local variable,
+  and never logged, cached, or written elsewhere (`AppState.token`). Newer
+  cux versions (v0.2.11+) keep the real token only in the macOS Keychain, not
+  in any slot's `oauth.json`, so `token(for:)` falls back to
+  `AccountDiscovery.keychainAccessToken()` — but only when `account.isActive`,
+  since cux swaps just the active slot's token into the Keychain and applying
+  the fallback to inactive accounts would misattribute that token to them.
 
 ## Workflow
 

--- a/Sources/ClaudeStatusBar/AppState.swift
+++ b/Sources/ClaudeStatusBar/AppState.swift
@@ -213,9 +213,17 @@ final class AppState {
         }
     }
 
-    /// Token is read at fetch time only, kept in a local, never stored or logged.
+    /// Token is read at fetch time only, kept in a local, never stored or
+    /// logged. cux v0.2.11+ keeps the real token only in the Keychain, never
+    /// in a slot's oauth.json — but cux swaps just the *active* slot's token
+    /// into the Keychain, so the fallback is gated on `isActive` to avoid
+    /// misattributing that token to other, inactive accounts.
     private func token(for account: Account) -> String? {
-        guard let data = try? Data(contentsOf: account.oauthURL) else { return nil }
-        return AccountDiscovery.accessToken(from: data)
+        if let data = try? Data(contentsOf: account.oauthURL),
+           let token = AccountDiscovery.accessToken(from: data) {
+            return token
+        }
+        guard account.isActive else { return nil }
+        return AccountDiscovery.keychainAccessToken()
     }
 }

--- a/Sources/StatusBarCore/Accounts/AccountDiscovery.swift
+++ b/Sources/StatusBarCore/Accounts/AccountDiscovery.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 
 public struct Account: Equatable, Sendable, Identifiable {
     public let id: String
@@ -92,5 +93,29 @@ public enum AccountDiscovery {
             return nil
         }
         return obj["organizationUuid"] as? String
+    }
+
+    /// cux v0.2.11+ keeps the real bearer token only in the macOS Keychain
+    /// (item labeled "Claude Code-credentials"), not in any slot's
+    /// oauth.json. `reader` is injectable so tests can exercise the parsing
+    /// path without touching the real Keychain.
+    public static func keychainAccessToken(
+        service: String = "Claude Code-credentials",
+        reader: (String) -> Data? = defaultKeychainReader
+    ) -> String? {
+        reader(service).flatMap(accessToken(from:))
+    }
+
+    public static func defaultKeychainReader(service: String) -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrLabel as String: service,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data else { return nil }
+        return data
     }
 }

--- a/Sources/StatusBarCore/Usage/CuxUsageCache.swift
+++ b/Sources/StatusBarCore/Usage/CuxUsageCache.swift
@@ -15,16 +15,21 @@ public enum CuxUsageCache {
     /// Entries without a parsable polled_at or without any usage window are
     /// dropped — no timestamp means no freshness story, no windows means
     /// nothing to show.
+    ///
+    /// Newer cux versions key entries as "accountUuid|organizationUuid"
+    /// rather than a bare organizationUuid; the trailing segment is what
+    /// callers join on, so compound keys are split before storing.
     public static func parse(_ data: Data) -> [String: UsageSnapshot] {
         guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return [:]
         }
         var result: [String: UsageSnapshot] = [:]
-        for (orgUuid, value) in root {
+        for (key, value) in root {
             guard let entry = value as? [String: Any],
                   let polledAt = (entry["polled_at"] as? String).flatMap(ISO8601.parse),
                   let snapshot = UsageSnapshot.parse(object: entry, fetchedAt: polledAt)
             else { continue }
+            let orgUuid = key.split(separator: "|").last.map(String.init) ?? key
             result[orgUuid] = snapshot
         }
         return result

--- a/Tests/StatusBarCoreTests/AccountDiscoveryTests.swift
+++ b/Tests/StatusBarCoreTests/AccountDiscoveryTests.swift
@@ -126,3 +126,38 @@ private func makeCuxFixture(in root: URL) throws {
         #expect(AccountDiscovery.accessToken(from: Data("{}".utf8)) == nil)
     }
 }
+
+/// SecItemCopyMatching itself can't be exercised in a unit test, so
+/// keychainAccessToken takes an injectable reader — these tests cover the
+/// parsing/integration path around it, not the real Keychain call.
+@Suite struct KeychainAccessTokenTests {
+    @Test func returnsTokenParsedFromReaderData() {
+        let data = Data(#"{"claudeAiOauth":{"accessToken":"keychain-token"}}"#.utf8)
+        let token = AccountDiscovery.keychainAccessToken(
+            service: "Claude Code-credentials", reader: { _ in data })
+        #expect(token == "keychain-token")
+    }
+
+    @Test func passesServiceThroughToReader() {
+        var seenService: String?
+        _ = AccountDiscovery.keychainAccessToken(
+            service: "Claude Code-credentials",
+            reader: { service in
+                seenService = service
+                return nil
+            })
+        #expect(seenService == "Claude Code-credentials")
+    }
+
+    @Test func nilWhenReaderFindsNothing() {
+        let token = AccountDiscovery.keychainAccessToken(
+            service: "Claude Code-credentials", reader: { _ in nil })
+        #expect(token == nil)
+    }
+
+    @Test func nilWhenReaderDataIsMalformed() {
+        let token = AccountDiscovery.keychainAccessToken(
+            service: "Claude Code-credentials", reader: { _ in Data("nope".utf8) })
+        #expect(token == nil)
+    }
+}

--- a/Tests/StatusBarCoreTests/CuxUsageCacheTests.swift
+++ b/Tests/StatusBarCoreTests/CuxUsageCacheTests.swift
@@ -15,7 +15,11 @@ private let fixture = """
     "polled_at": "2026-07-11T09:14:33Z"
   },
   "org-no-windows": { "polled_at": "2026-07-11T09:14:33Z" },
-  "org-no-polled-at": { "five_hour": { "utilization": 50 } }
+  "org-no-polled-at": { "five_hour": { "utilization": 50 } },
+  "acct-ccc|org-ccc": {
+    "five_hour": { "utilization": 42 },
+    "polled_at": "2026-07-11T09:14:33Z"
+  }
 }
 """
 
@@ -37,7 +41,16 @@ private let fixture = """
         let cache = CuxUsageCache.parse(Data(fixture.utf8))
         #expect(cache["org-no-windows"] == nil)
         #expect(cache["org-no-polled-at"] == nil)
-        #expect(cache.count == 2)
+        #expect(cache.count == 3)
+    }
+
+    /// Newer cux versions key entries as "accountUuid|organizationUuid"
+    /// instead of a bare organizationUuid — the join in AppState.usageInputs
+    /// looks up by organizationUuid alone, so the compound key must be split.
+    @Test func splitsCompoundAccountOrgKey() {
+        let cache = CuxUsageCache.parse(Data(fixture.utf8))
+        #expect(cache["org-ccc"]?.fiveHour?.utilization == 42)
+        #expect(cache["acct-ccc|org-ccc"] == nil)
     }
 
     @Test func malformedDataYieldsEmpty() {
@@ -56,6 +69,6 @@ private let fixture = """
             .appendingPathComponent("cux-cache-\(UUID().uuidString).json")
         defer { try? FileManager.default.removeItem(at: file) }
         try Data(fixture.utf8).write(to: file)
-        #expect(CuxUsageCache.load(file: file).count == 2)
+        #expect(CuxUsageCache.load(file: file).count == 3)
     }
 }


### PR DESCRIPTION
## Summary

Fixes two independent bugs from #16 that together cause the menu bar to never show usage percentages for cux-managed (multi-account) users on newer cux versions:

- **Cache key mismatch**: newer cux writes `~/.cux/runtime/usage-cache.json` entries keyed as `"accountUuid|organizationUuid"` instead of a bare `organizationUuid`. `AppState.usageInputs` joins the cache by `organizationUuid` alone, so the lookup always missed even though the data was present. `CuxUsageCache.parse` now splits compound keys and keeps the trailing `organizationUuid` segment (plain keys from older cux are unaffected).
- **Missing token**: cux v0.2.11+ stores the real OAuth token only in the macOS Keychain (`"Claude Code-credentials"`), never in a slot's `oauth.json`. `AppState.token(for:)` only read `oauth.json`, so it always got `nil` and skipped the direct API-fetch path. Added `AccountDiscovery.keychainAccessToken()` (via `SecItemCopyMatching`, injectable reader for tests) as a fallback — gated on `account.isActive`, since cux only swaps the *active* slot's token into the Keychain, so applying the fallback to inactive accounts would misattribute that token to them.

## Test plan
- [x] `swift test` — full suite passes (160 tests, including new `splitsCompoundAccountOrgKey` and `KeychainAccessTokenTests` cases)
- [x] `swift build` succeeds
- [x] TDD: each fix was preceded by a failing test confirming the bug, then made to pass

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)