### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/Sources/StatusBarCore/StatusBarCore.swift
+++ b/Sources/StatusBarCore/StatusBarCore.swift
@@ -1,3 +1,3 @@
 public enum StatusBarCoreInfo {
-    public static let version = "0.1.1"
+    public static let version = "0.1.2"
 }

--- a/Tests/StatusBarCoreTests/PackageTests.swift
+++ b/Tests/StatusBarCoreTests/PackageTests.swift
@@ -2,5 +2,5 @@ import Testing
 @testable import StatusBarCore
 
 @Test func versionIsSet() {
-    #expect(StatusBarCoreInfo.version == "0.1.1")
+    #expect(StatusBarCoreInfo.version == "0.1.2")
 }

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-VERSION="${VERSION:-0.1.1}"
+VERSION="${VERSION:-0.1.2}"
 APP="dist/ClaudeStatusBar.app"
 BIN=".build/release"
 


### PR DESCRIPTION
## Summary
- Bumps the version string (`StatusBarCoreInfo.version`, `PackageTests`, `scripts/make-app.sh`'s `VERSION` default) from 0.1.1 to 0.1.2, following the same pattern as the 0.1.1 bump.
- This release will include the cux Keychain-token and compound-cache-key fixes from #16 (#19), already merged to `main`.

## Test plan
- [x] `swift test` — full suite passes (160 tests, including updated `versionIsSet`)