### PR TITLE
fix: resolve cux switch failures and repeated Keychain prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ with multi-account support.
 
 3. **First launch / Gatekeeper**
 
-   The app is ad-hoc signed, so macOS quarantines it and the first launch is
-   refused ("cannot verify" / "damaged") — expected either way you installed
-   it. Right-click the app in Applications and choose **Open** (twice if
-   needed), or clear the quarantine flag directly:
+   The app is self-signed (not notarized by Apple), so macOS quarantines it
+   and the first launch is refused ("cannot verify" / "damaged") — expected
+   either way you installed it. Right-click the app in Applications and
+   choose **Open** (twice if needed), or clear the quarantine flag directly:
 
    ```sh
    xattr -d com.apple.quarantine /Applications/ClaudeStatusBar.app
@@ -114,6 +114,14 @@ make test    # unit + integration tests
 make app     # dist/ClaudeStatusBar.app
 make dmg     # dist/ClaudeStatusBar.dmg
 ```
+
+`make app` signs the app with a self-signed "ClaudeStatusBar Local Signing"
+identity, generating it into your login keychain on first run if it doesn't
+already exist (`scripts/ensure-signing-identity.sh`). Keeping this identity
+stable across rebuilds — rather than ad-hoc signing, which re-derives its
+identity from the binary's own bytes every build — is what lets macOS
+Keychain "Always Allow" grants (e.g. for cux account credentials) survive
+rebuilding and reinstalling the app.
 
 ## Security notes
 

--- a/Sources/StatusBarCore/Accounts/CuxAccountSwitcher.swift
+++ b/Sources/StatusBarCore/Accounts/CuxAccountSwitcher.swift
@@ -34,30 +34,13 @@ public actor CuxAccountSwitcher {
         return await run(binary, ["switch", String(slot)])
     }
 
-    /// Runs `<binary> <arguments>`, discarding output. Returns true only on
-    /// exit status 0. Terminates the process if it outlives `timeout`
-    /// (terminate() still fires the termination handler, so the continuation
-    /// is resumed exactly once).
-    public static func invoke(binary: String, arguments: [String], timeout: TimeInterval) async -> Bool {
-        await withCheckedContinuation { continuation in
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: binary)
-            process.arguments = arguments
-            process.standardOutput = FileHandle.nullDevice
-            process.standardError = FileHandle.nullDevice
-            process.terminationHandler = { finished in
-                continuation.resume(returning: finished.terminationStatus == 0)
-            }
-            do {
-                try process.run()
-            } catch {
-                process.terminationHandler = nil
-                continuation.resume(returning: false)
-                return
-            }
-            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
-                if process.isRunning { process.terminate() }
-            }
-        }
+    /// Runs `<binary> <arguments>` via `CuxShellInvoker`, discarding output.
+    /// Returns true only on exit status 0. `environment` is nil in
+    /// production (inherit) — tests override it to exercise PATH resolution
+    /// hermetically.
+    public static func invoke(binary: String, arguments: [String], timeout: TimeInterval,
+                              environment: [String: String]? = nil) async -> Bool {
+        await CuxShellInvoker.invoke(binary: binary, arguments: arguments, timeout: timeout,
+                                     environment: environment)
     }
 }

--- a/Sources/StatusBarCore/CuxShellInvoker.swift
+++ b/Sources/StatusBarCore/CuxShellInvoker.swift
@@ -1,0 +1,113 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
+
+/// Shared subprocess invocation behind `CuxAccountSwitcher.invoke` and
+/// `CuxRefresher.invoke`.
+///
+/// cux is a Node script (`#!/usr/bin/env node`), typically installed via a
+/// version manager like nvm, whose PATH setup is sourced only by
+/// interactive shell startup files (~/.zshrc). A GUI app launched by
+/// LaunchServices inherits only the bare `/usr/bin:/bin:/usr/sbin:/sbin`
+/// PATH, under which the shebang's `env node` step can't find `node`.
+/// Routing the call through an interactive zsh (`-ilc`) makes the shell
+/// resolve `node` itself, exactly as it would in the user's own terminal —
+/// the same assumption TerminalLauncher already makes about the user's
+/// shell being zsh.
+enum CuxShellInvoker {
+    /// Runs `<binary> <arguments>` inside an interactive zsh, discarding
+    /// output. Returns true only on exit status 0. Terminates the process
+    /// if it outlives `timeout` (terminate() still fires the termination
+    /// handler, so the continuation is resumed exactly once).
+    /// `environment` defaults to nil (inherit the app's own environment,
+    /// including whatever HOME LaunchServices set — that's what lets zsh
+    /// find the user's real ~/.zshrc); tests override it to point zsh's rc
+    /// lookup at a hermetic fixture instead.
+    static func invoke(binary: String, arguments: [String], timeout: TimeInterval,
+                       environment: [String: String]? = nil) async -> Bool {
+        await withCheckedContinuation { continuation in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+            process.arguments = ["-ilc", command(binary: binary, arguments: arguments)]
+            if let environment {
+                process.environment = environment
+            }
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            process.terminationHandler = { finished in
+                continuation.resume(returning: finished.terminationStatus == 0)
+            }
+            do {
+                try process.run()
+            } catch {
+                process.terminationHandler = nil
+                continuation.resume(returning: false)
+                return
+            }
+            // zsh's shebang chain (env -> node, or a plain script's shell
+            // interpreter) can fork further children of its own — e.g. `sh`
+            // running a script forks a separate PID for the script's last
+            // command rather than exec-ing into it. process.terminate() only
+            // signals the single PID Process tracks, so a hang further down
+            // the tree would outlive it. Moving the child into its own
+            // process group at timeout (so the whole group could be killed
+            // at once) doesn't work: setpgid() fails with EACCES once the
+            // target has already exec'd, and process.run() only returns
+            // after that initial exec into zsh has already happened —
+            // confirmed empirically, not just per POSIX docs. Walking the
+            // live process tree at timeout and signaling every descendant
+            // individually sidesteps that restriction (kill() has no
+            // exec-history restriction, unlike setpgid()).
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
+                guard process.isRunning else { return }
+                for pid in descendantPIDs(of: process.processIdentifier) {
+                    kill(pid, SIGTERM)
+                }
+                process.terminate()
+            }
+        }
+    }
+
+    /// Snapshots the system-wide pid/ppid table via `ps` and returns every
+    /// transitive descendant of `pid`, deepest-first order not guaranteed
+    /// (callers signal them all, so order doesn't matter).
+    private static func descendantPIDs(of pid: pid_t) -> [pid_t] {
+        let ps = Process()
+        ps.executableURL = URL(fileURLWithPath: "/bin/ps")
+        ps.arguments = ["-axo", "pid=,ppid="]
+        let pipe = Pipe()
+        ps.standardOutput = pipe
+        ps.standardError = FileHandle.nullDevice
+        guard (try? ps.run()) != nil else { return [] }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        ps.waitUntilExit()
+        guard let output = String(data: data, encoding: .utf8) else { return [] }
+
+        var childrenByParent: [pid_t: [pid_t]] = [:]
+        for line in output.split(separator: "\n") {
+            let fields = line.split(separator: " ", omittingEmptySubsequences: true)
+            guard fields.count >= 2, let childPID = pid_t(fields[0]), let parentPID = pid_t(fields[1]) else {
+                continue
+            }
+            childrenByParent[parentPID, default: []].append(childPID)
+        }
+
+        var result: [pid_t] = []
+        var queue = [pid]
+        while let current = queue.popLast() {
+            let children = childrenByParent[current] ?? []
+            result.append(contentsOf: children)
+            queue.append(contentsOf: children)
+        }
+        return result
+    }
+
+    private static func command(binary: String, arguments: [String]) -> String {
+        ([binary] + arguments).map(quote).joined(separator: " ")
+    }
+
+    private static func quote(_ argument: String) -> String {
+        "'" + argument.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}

--- a/Sources/StatusBarCore/Usage/CuxRefresher.swift
+++ b/Sources/StatusBarCore/Usage/CuxRefresher.swift
@@ -43,30 +43,13 @@ public actor CuxRefresher {
         _ = await run(binary)
     }
 
-    /// Runs `<binary> usage refresh`, discarding output. Returns true only on
-    /// exit status 0. Terminates the process if it outlives `timeout`
-    /// (terminate() still fires the termination handler, so the continuation
-    /// is resumed exactly once).
-    public static func invoke(binary: String, timeout: TimeInterval) async -> Bool {
-        await withCheckedContinuation { continuation in
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: binary)
-            process.arguments = ["usage", "refresh"]
-            process.standardOutput = FileHandle.nullDevice
-            process.standardError = FileHandle.nullDevice
-            process.terminationHandler = { finished in
-                continuation.resume(returning: finished.terminationStatus == 0)
-            }
-            do {
-                try process.run()
-            } catch {
-                process.terminationHandler = nil
-                continuation.resume(returning: false)
-                return
-            }
-            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
-                if process.isRunning { process.terminate() }
-            }
-        }
+    /// Runs `<binary> usage refresh` via `CuxShellInvoker`, discarding output.
+    /// Returns true only on exit status 0. `environment` is nil in
+    /// production (inherit) — tests override it to exercise PATH resolution
+    /// hermetically.
+    public static func invoke(binary: String, timeout: TimeInterval,
+                              environment: [String: String]? = nil) async -> Bool {
+        await CuxShellInvoker.invoke(binary: binary, arguments: ["usage", "refresh"],
+                                     timeout: timeout, environment: environment)
     }
 }

--- a/Tests/StatusBarCoreTests/CuxRefresherTests.swift
+++ b/Tests/StatusBarCoreTests/CuxRefresherTests.swift
@@ -104,8 +104,18 @@ struct CuxRefresherTests {
         try FileManager.default.setAttributes([.posixPermissions: 0o755],
                                               ofItemAtPath: hang.path)
 
+        // A hermetic HOME (no real ~/.zshrc) keeps interactive zsh startup
+        // near-instant. Inheriting the real environment here would let the
+        // developer machine's actual ~/.zshrc (nvm hooks etc.) race past
+        // this test's short timeout before the hung process even forks,
+        // so the kill would target rc-loading helpers instead of the hang.
+        let emptyHome = dir.appendingPathComponent("empty-home")
+        try FileManager.default.createDirectory(at: emptyHome, withIntermediateDirectories: true)
+
         let started = Date()
-        #expect(await CuxRefresher.invoke(binary: hang.path, timeout: 0.5) == false)
+        #expect(await CuxRefresher.invoke(
+            binary: hang.path, timeout: 0.5,
+            environment: ["HOME": emptyHome.path, "PATH": "/usr/bin:/bin:/usr/sbin:/sbin"]) == false)
         #expect(Date().timeIntervalSince(started) < 5)
     }
 }

--- a/Tests/StatusBarCoreTests/CuxShellInvokerTests.swift
+++ b/Tests/StatusBarCoreTests/CuxShellInvokerTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+@testable import StatusBarCore
+
+@Suite("CuxShellInvoker")
+struct CuxShellInvokerTests {
+    @Test("resolves PATH the way an interactive shell's rc file would")
+    func resolvesPathViaInteractiveShellRC() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cux-shell-invoker-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let fakeBinDir = dir.appendingPathComponent("fakebin")
+        try FileManager.default.createDirectory(at: fakeBinDir, withIntermediateDirectories: true)
+        let interpreter = fakeBinDir.appendingPathComponent("fake-node-test")
+        try "#!/bin/sh\nexit 0\n".write(to: interpreter, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755],
+                                              ofItemAtPath: interpreter.path)
+
+        let launcher = dir.appendingPathComponent("fake-cux")
+        try "#!/usr/bin/env fake-node-test\n".write(to: launcher, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755],
+                                              ofItemAtPath: launcher.path)
+
+        let zdotdir = dir.appendingPathComponent("zdotdir")
+        try FileManager.default.createDirectory(at: zdotdir, withIntermediateDirectories: true)
+        try "export PATH=\"$FAKE_BIN_DIR:$PATH\"\n"
+            .write(to: zdotdir.appendingPathComponent(".zshrc"), atomically: true, encoding: .utf8)
+
+        let repairedResult = await CuxShellInvoker.invoke(
+            binary: launcher.path, arguments: [], timeout: 5,
+            environment: [
+                "HOME": zdotdir.path,
+                "ZDOTDIR": zdotdir.path,
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "FAKE_BIN_DIR": fakeBinDir.path,
+            ])
+        #expect(repairedResult == true)
+
+        let emptyHome = dir.appendingPathComponent("empty-home")
+        try FileManager.default.createDirectory(at: emptyHome, withIntermediateDirectories: true)
+        let unrepairedResult = await CuxShellInvoker.invoke(
+            binary: launcher.path, arguments: [], timeout: 5,
+            environment: [
+                "HOME": emptyHome.path,
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            ])
+        #expect(unrepairedResult == false)
+    }
+
+    @Test("quotes arguments containing spaces so they survive shell parsing")
+    func quotesArgumentsWithSpaces() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cux-shell-invoker-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let marker = dir.appendingPathComponent("marker.txt")
+        let script = dir.appendingPathComponent("capture.sh")
+        try "#!/bin/sh\nprintf '%s' \"$1\" > \"\(marker.path)\"\n"
+            .write(to: script, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755],
+                                              ofItemAtPath: script.path)
+
+        let result = await CuxShellInvoker.invoke(
+            binary: script.path, arguments: ["hello world"], timeout: 5,
+            environment: ["HOME": dir.path, "PATH": "/usr/bin:/bin:/usr/sbin:/sbin"])
+        #expect(result == true)
+        let captured = try String(contentsOf: marker, encoding: .utf8)
+        #expect(captured == "hello world")
+    }
+}

--- a/scripts/ensure-signing-identity.sh
+++ b/scripts/ensure-signing-identity.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Ensures a stable, self-signed code-signing identity exists in the login
+# keychain, and exports its name as SIGNING_IDENTITY. Meant to be sourced
+# by scripts/make-app.sh before its codesign step, not run standalone.
+#
+# Ad-hoc signing (`codesign --sign -`) derives its designated requirement
+# from a hash of the binary's own bytes, so it changes on every rebuild.
+# macOS ties Keychain "Always Allow" grants (e.g. for the cux credentials
+# this app reads) to the requesting app's designated requirement, so an
+# identity that changes on every build invalidates those grants and forces
+# a re-prompt on every launch. Signing with a real certificate — even a
+# self-signed one — anchors the requirement to the certificate instead of
+# the binary content, so it survives rebuilds.
+set -euo pipefail
+
+SIGNING_IDENTITY_NAME="ClaudeStatusBar Local Signing"
+LOGIN_KEYCHAIN="$HOME/Library/Keychains/login.keychain-db"
+
+# find-identity filters by trust validity, which a self-signed leaf cert
+# never satisfies (no trusted anchor) even once codesign is already using
+# it successfully — so check for the certificate's existence directly
+# instead of asking whether it's a "valid" identity.
+if ! security find-certificate -c "$SIGNING_IDENTITY_NAME" "$LOGIN_KEYCHAIN" >/dev/null 2>&1; then
+  echo "No local signing identity found — creating '$SIGNING_IDENTITY_NAME'..." >&2
+  WORKDIR=$(mktemp -d)
+  trap 'rm -rf "$WORKDIR"' EXIT
+
+  openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+    -keyout "$WORKDIR/key.pem" -out "$WORKDIR/cert.pem" \
+    -subj "/CN=$SIGNING_IDENTITY_NAME" \
+    -addext "keyUsage=critical,digitalSignature" \
+    -addext "extendedKeyUsage=critical,codeSigning" \
+    -addext "basicConstraints=critical,CA:FALSE" >/dev/null 2>&1
+
+  # -legacy: keeps the p12 in an encoding `security import` reliably reads
+  # (OpenSSL 3's default pkcs12 cipher is newer than what Security.framework
+  # expects). The export password is a fixed placeholder, not a secret — the
+  # p12 file is deleted with $WORKDIR right after import; the private key's
+  # real protection is the login keychain's own ACLs.
+  openssl pkcs12 -export -legacy -passout pass:claude-status-bar \
+    -inkey "$WORKDIR/key.pem" -in "$WORKDIR/cert.pem" \
+    -out "$WORKDIR/identity.p12"
+
+  # -T trusts codesign/security to use the key, but on a real login keychain
+  # (as opposed to an isolated test keychain) that trust alone still leaves
+  # the very first signing attempt blocked on an interactive "codesign wants
+  # to use your key" GUI prompt. set-key-partition-list pre-authorizes that
+  # access up front instead, at the cost of one native macOS password prompt
+  # here, right now, at identity-creation time — never again on later builds.
+  security import "$WORKDIR/identity.p12" -k "$LOGIN_KEYCHAIN" -P claude-status-bar \
+    -T /usr/bin/codesign -T /usr/bin/security
+
+  # No -k here: that flag takes the keychain's literal unlock password, not
+  # a path, and we deliberately never handle or hardcode that password —
+  # omitting it makes security prompt the user via the native GUI instead.
+  security set-key-partition-list -S apple-tool:,apple:,codesign: -s "$LOGIN_KEYCHAIN"
+fi
+
+export SIGNING_IDENTITY="$SIGNING_IDENTITY_NAME"

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -76,5 +76,6 @@ cat > "$APP/Contents/Info.plist" <<PLIST
 </plist>
 PLIST
 
-codesign --force --deep --sign - "$APP"
+source scripts/ensure-signing-identity.sh
+codesign --force --deep --sign "$SIGNING_IDENTITY" "$APP"
 echo "Built $APP (version $VERSION)"


### PR DESCRIPTION
## Summary
- Route `cux switch`/`cux usage refresh` subprocess calls through an interactive `zsh -ilc` invocation (`CuxShellInvoker`) so `node` resolves the same way it does in the user's own terminal — a GUI app launched via LaunchServices only inherits the bare PATH, so the previous direct exec of cux's `#!/usr/bin/env node` shebang couldn't find `node` when installed via a version manager, and the switch failed outright.
- On timeout, walk the live process tree and signal every descendant individually instead of relying on `setpgid()` + process-group kill, which fails with `EACCES` once the child has already exec'd — `process.run()` only returns after the initial exec into zsh has already happened (confirmed empirically).
- Stabilize app code-signing on a self-signed certificate kept in the login keychain (`scripts/ensure-signing-identity.sh`) instead of ad-hoc signing (`--sign -`), since macOS ties Keychain "Always Allow" grants (e.g. cux credential access) to the signer's designated requirement — ad-hoc signing rederives that requirement from the binary's own bytes on every rebuild, forcing a fresh permission prompt on every launch.

## Test plan
- [x] `swift test` — 162/162 passing, including `CuxShellInvokerTests` (PATH resolution via interactive shell rc, argument quoting) and `CuxRefresherTests` (hung-process timeout kill, hermetic environment)
- [ ] CI (`swift test` + hook integration test) passes on this PR
- [ ] Manual: `make app`, switch cux accounts repeatedly, confirm no repeated Keychain prompt and no switch failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)