### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/Sources/StatusBarCore/StatusBarCore.swift
+++ b/Sources/StatusBarCore/StatusBarCore.swift
@@ -1,3 +1,3 @@
 public enum StatusBarCoreInfo {
-    public static let version = "0.1.2"
+    public static let version = "0.1.3"
 }

--- a/Tests/StatusBarCoreTests/PackageTests.swift
+++ b/Tests/StatusBarCoreTests/PackageTests.swift
@@ -2,5 +2,5 @@ import Testing
 @testable import StatusBarCore
 
 @Test func versionIsSet() {
-    #expect(StatusBarCoreInfo.version == "0.1.2")
+    #expect(StatusBarCoreInfo.version == "0.1.3")
 }

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-VERSION="${VERSION:-0.1.2}"
+VERSION="${VERSION:-0.1.3}"
 APP="dist/ClaudeStatusBar.app"
 BIN=".build/release"
 


### PR DESCRIPTION
## Summary
- Version bump 0.1.2 → 0.1.3 to match the next release tag, following the same pattern as the previous bump (commit 4965acf).
- Ships the version-display / check-for-updates feature and the DMG Applications-folder shortcut (#22).

## Test plan
- [x] `swift test` — 183/183 passing

https://claude.ai/code/session_01WPgDrgVj3ctuBvhyNLKhSt