### PR TITLE
fix: stop re-prompting Keychain on every account switch/poll

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,11 @@ features (e.g. exit tests, custom traits) when writing tests here.
   `AccountDiscovery.keychainAccessToken()` — but only when `account.isActive`,
   since cux swaps just the active slot's token into the Keychain and applying
   the fallback to inactive accounts would misattribute that token to them.
+  That fallback is further gated on the account's org having no entry yet in
+  cux's own usage cache (`cached == nil`) — cux rewrites the shared Keychain
+  item on every `cux switch`, resetting macOS's "Always Allow" grant for it,
+  so an unconditional per-poll-cycle Keychain read re-prompts the user
+  constantly for no benefit once a cached snapshot already covers that org.
 
 ## Workflow
 

--- a/Sources/ClaudeStatusBar/AccountsSection.swift
+++ b/Sources/ClaudeStatusBar/AccountsSection.swift
@@ -10,6 +10,7 @@ struct AccountsSection: View {
     let yellowColor: Color
     let redColor: Color
     let now: Date
+    let switchFailedAccountId: String?
     let onSwitch: (Account) -> Void
 
     var body: some View {
@@ -25,7 +26,9 @@ struct AccountsSection: View {
                     AccountRow(account: account, state: states[account.id],
                                yellowAt: yellowAt, redAt: redAt, normalColor: normalColor,
                                yellowColor: yellowColor, redColor: redColor, now: now,
-                               showActiveBadge: accounts.count > 1, onSwitch: onSwitch)
+                               showActiveBadge: accounts.count > 1,
+                               switchFailed: switchFailedAccountId == account.id,
+                               onSwitch: onSwitch)
                 }
             }
         }
@@ -42,6 +45,7 @@ private struct AccountRow: View {
     let redColor: Color
     let now: Date
     let showActiveBadge: Bool
+    let switchFailed: Bool
     let onSwitch: (Account) -> Void
 
     var body: some View {
@@ -71,6 +75,10 @@ private struct AccountRow: View {
                         .font(.caption2).foregroundStyle(.green)
                         .help("Logged in")
                 }
+            }
+            if switchFailed {
+                Text("Switch failed — is cux installed and working?")
+                    .font(.caption2).foregroundStyle(.orange)
             }
             if let snapshot = state?.snapshot {
                 UsageBar(title: "5h", window: snapshot.fiveHour,

--- a/Sources/ClaudeStatusBar/AppState.swift
+++ b/Sources/ClaudeStatusBar/AppState.swift
@@ -22,6 +22,9 @@ final class AppState {
     private(set) var display: SessionRecord?
     private(set) var accounts: [Account] = []
     private(set) var currentVerb: String
+    /// Set when `switchAccount` fails, cleared on the next attempt that
+    /// succeeds — surfaced as an inline warning next to the account's row.
+    private(set) var switchFailedAccountId: String?
     /// 1 Hz heartbeat for the menu bar elapsed counter; advances only while busy.
     private(set) var tick = Date()
     private(set) var updateAvailable: ReleaseInfo?
@@ -185,7 +188,8 @@ final class AppState {
     /// has nothing to switch to.
     func switchAccount(_ account: Account) async {
         guard let slot = account.slot else { return }
-        _ = await cuxAccountSwitcher.switchTo(slot: slot)
+        let succeeded = await cuxAccountSwitcher.switchTo(slot: slot)
+        switchFailedAccountId = succeeded ? nil : account.id
         await refreshUsageNow()
     }
 
@@ -232,8 +236,8 @@ final class AppState {
         let cache = CuxUsageCache.load(
             file: cuxRoot.appendingPathComponent("runtime/usage-cache.json"))
         return accounts.map { account in
-            (account, token(for: account),
-             account.organizationUuid.flatMap { cache[$0] })
+            let cached = account.organizationUuid.flatMap { cache[$0] }
+            return (account, token(for: account, cached: cached), cached)
         }
     }
 
@@ -242,12 +246,22 @@ final class AppState {
     /// in a slot's oauth.json — but cux swaps just the *active* slot's token
     /// into the Keychain, so the fallback is gated on `isActive` to avoid
     /// misattributing that token to other, inactive accounts.
-    private func token(for account: Account) -> String? {
+    ///
+    /// Also gated on `cached == nil`: cux rewrites the shared Keychain item
+    /// on every `cux switch`, which resets macOS's "Always Allow" grant for
+    /// it, so touching the Keychain is what actually re-prompts the user —
+    /// not the switch itself. A cux-cache snapshot (even a stale one) is
+    /// already enough for UsageStore to display usage, so once cux has
+    /// cached anything for this account's org there's nothing left for the
+    /// Keychain read to buy beyond a fresher percentage, at the cost of a
+    /// prompt on every poll cycle. Only fall back to the Keychain when cux
+    /// hasn't cached this org at all yet (e.g. a brand-new slot).
+    private func token(for account: Account, cached: UsageSnapshot?) -> String? {
         if let data = try? Data(contentsOf: account.oauthURL),
            let token = AccountDiscovery.accessToken(from: data) {
             return token
         }
-        guard account.isActive else { return nil }
+        guard account.isActive, cached == nil else { return nil }
         return AccountDiscovery.keychainAccessToken()
     }
 }

--- a/Sources/ClaudeStatusBar/PopoverView.swift
+++ b/Sources/ClaudeStatusBar/PopoverView.swift
@@ -22,6 +22,7 @@ struct PopoverView: View {
                                 yellowColor: Color(hex: appState.settings.yellowColorHex) ?? .yellow,
                                 redColor: Color(hex: appState.settings.redColorHex) ?? .red,
                                 now: context.date,
+                                switchFailedAccountId: appState.switchFailedAccountId,
                                 onSwitch: { account in
                                     Task { await appState.switchAccount(account) }
                                 })


### PR DESCRIPTION
## Summary
- `token(for:)` fell back to the Keychain unconditionally for the active account on every poll cycle. cux rewrites the shared Keychain item on every `cux switch`, resetting macOS's "Always Allow" grant — so switching accounts (and the background poll loop afterward) kept re-prompting for access. The fallback is now gated on the account's org having no `cux` cache entry yet: a cached snapshot is already enough for `UsageStore` to show usage, so the Keychain read only buys anything for a brand-new slot cux hasn't cached at all.
- `switchAccount` previously discarded the `Bool` result of `cuxAccountSwitcher.switchTo(slot:)` silently. It now surfaces a failed switch as an inline warning next to the account's row instead of failing silently.

## Test plan
- [x] `swift build` — clean build
- [x] `swift test` — full suite, 183/183 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPgDrgVj3ctuBvhyNLKhSt