### PR TITLE
fix: cux usage-cache key collisions + subprocess diagnostics

### DIFF
--- a/Sources/StatusBarCore/Accounts/CuxAccountSwitcher.swift
+++ b/Sources/StatusBarCore/Accounts/CuxAccountSwitcher.swift
@@ -34,13 +34,17 @@ public actor CuxAccountSwitcher {
         return await run(binary, ["switch", String(slot)])
     }
 
-    /// Runs `<binary> <arguments>` via `CuxShellInvoker`, discarding output.
-    /// Returns true only on exit status 0. `environment` is nil in
-    /// production (inherit) — tests override it to exercise PATH resolution
-    /// hermetically.
+    /// Runs `<binary> <arguments>` via `CuxShellInvoker`. Returns true only on
+    /// exit status 0. `environment` is nil in production (inherit) — tests
+    /// override it to exercise PATH resolution hermetically. `diagnosticLog`
+    /// defaults to a real path under `AppPaths().root` so production
+    /// switches always leave behind evidence of the last attempt; tests
+    /// override it to a temp path to avoid touching the real app support dir.
     public static func invoke(binary: String, arguments: [String], timeout: TimeInterval,
-                              environment: [String: String]? = nil) async -> Bool {
+                              environment: [String: String]? = nil,
+                              diagnosticLog: URL? = AppPaths().root
+                                  .appendingPathComponent("cux-switch.log")) async -> Bool {
         await CuxShellInvoker.invoke(binary: binary, arguments: arguments, timeout: timeout,
-                                     environment: environment)
+                                     environment: environment, diagnosticLog: diagnosticLog)
     }
 }

--- a/Sources/StatusBarCore/CuxShellInvoker.swift
+++ b/Sources/StatusBarCore/CuxShellInvoker.swift
@@ -16,32 +16,68 @@ import Darwin
 /// the same assumption TerminalLauncher already makes about the user's
 /// shell being zsh.
 enum CuxShellInvoker {
-    /// Runs `<binary> <arguments>` inside an interactive zsh, discarding
-    /// output. Returns true only on exit status 0. Terminates the process
-    /// if it outlives `timeout` (terminate() still fires the termination
-    /// handler, so the continuation is resumed exactly once).
+    /// Runs `<binary> <arguments>` inside an interactive zsh. Returns true
+    /// only on exit status 0. Terminates the process if it outlives
+    /// `timeout` (terminate() still fires the termination handler, so the
+    /// continuation is resumed exactly once).
     /// `environment` defaults to nil (inherit the app's own environment,
     /// including whatever HOME LaunchServices set — that's what lets zsh
     /// find the user's real ~/.zshrc); tests override it to point zsh's rc
     /// lookup at a hermetic fixture instead.
+    /// `diagnosticLog`, when non-nil, overwrites that file with a snapshot
+    /// (command, duration, exit status, captured stdout/stderr) of this one
+    /// invocation — there to give the still-unexplained Keychain re-prompt
+    /// bug real evidence instead of the silent `Bool` this used to return.
+    /// Defaults to nil so tests that don't ask for it stay side-effect-free.
     static func invoke(binary: String, arguments: [String], timeout: TimeInterval,
-                       environment: [String: String]? = nil) async -> Bool {
-        await withCheckedContinuation { continuation in
+                       environment: [String: String]? = nil,
+                       diagnosticLog: URL? = nil) async -> Bool {
+        let startedAt = Date()
+        return await withCheckedContinuation { continuation in
             let process = Process()
             process.executableURL = URL(fileURLWithPath: "/bin/zsh")
             process.arguments = ["-ilc", command(binary: binary, arguments: arguments)]
             if let environment {
                 process.environment = environment
             }
-            process.standardOutput = FileHandle.nullDevice
-            process.standardError = FileHandle.nullDevice
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+            if diagnosticLog != nil {
+                process.standardOutput = stdoutPipe
+                process.standardError = stderrPipe
+            } else {
+                process.standardOutput = FileHandle.nullDevice
+                process.standardError = FileHandle.nullDevice
+            }
             process.terminationHandler = { finished in
+                if let diagnosticLog {
+                    // Reading here (rather than an async readabilityHandler)
+                    // can block if a surviving descendant still holds the
+                    // pipe's write end open — but that's bounded by the same
+                    // `timeout`-driven kill loop below, so it adds no new
+                    // unbounded hang.
+                    let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(),
+                                        encoding: .utf8) ?? ""
+                    let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(),
+                                        encoding: .utf8) ?? ""
+                    writeDiagnostic(to: diagnosticLog, binary: binary, arguments: arguments,
+                                    exitCode: finished.terminationStatus,
+                                    terminationReason: finished.terminationReason,
+                                    stdout: stdout, stderr: stderr,
+                                    duration: Date().timeIntervalSince(startedAt))
+                }
                 continuation.resume(returning: finished.terminationStatus == 0)
             }
             do {
                 try process.run()
             } catch {
                 process.terminationHandler = nil
+                if let diagnosticLog {
+                    writeDiagnostic(to: diagnosticLog, binary: binary, arguments: arguments,
+                                    exitCode: -1, terminationReason: .exit, stdout: "",
+                                    stderr: "process.run() failed: \(error)",
+                                    duration: Date().timeIntervalSince(startedAt))
+                }
                 continuation.resume(returning: false)
                 return
             }
@@ -101,6 +137,30 @@ enum CuxShellInvoker {
             queue.append(contentsOf: children)
         }
         return result
+    }
+
+    /// Overwrites `url` with a human-readable snapshot of one invocation.
+    /// Creates the parent directory if needed; silently drops the write on
+    /// any filesystem error since this is diagnostics, not core behavior.
+    private static func writeDiagnostic(to url: URL, binary: String, arguments: [String],
+                                        exitCode: Int32, terminationReason: Process.TerminationReason,
+                                        stdout: String, stderr: String, duration: TimeInterval) {
+        let reason = terminationReason == .exit ? "exit" : "uncaughtSignal"
+        let text = """
+        timestamp: \(Date())
+        command: \(command(binary: binary, arguments: arguments))
+        duration: \(String(format: "%.3f", duration))s
+        terminationReason: \(reason)
+        exitCode: \(exitCode)
+        --- stdout ---
+        \(stdout)
+        --- stderr ---
+        \(stderr)
+
+        """
+        try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                  withIntermediateDirectories: true)
+        try? text.write(to: url, atomically: true, encoding: .utf8)
     }
 
     private static func command(binary: String, arguments: [String]) -> String {

--- a/Sources/StatusBarCore/Usage/CuxRefresher.swift
+++ b/Sources/StatusBarCore/Usage/CuxRefresher.swift
@@ -43,13 +43,19 @@ public actor CuxRefresher {
         _ = await run(binary)
     }
 
-    /// Runs `<binary> usage refresh` via `CuxShellInvoker`, discarding output.
-    /// Returns true only on exit status 0. `environment` is nil in
-    /// production (inherit) — tests override it to exercise PATH resolution
-    /// hermetically.
+    /// Runs `<binary> usage refresh` via `CuxShellInvoker`. Returns true only
+    /// on exit status 0. `environment` is nil in production (inherit) —
+    /// tests override it to exercise PATH resolution hermetically.
+    /// `diagnosticLog` defaults to a real path under `AppPaths().root` so
+    /// production refreshes always leave behind evidence of the last
+    /// attempt; tests override it to a temp path to avoid touching the real
+    /// app support dir.
     public static func invoke(binary: String, timeout: TimeInterval,
-                              environment: [String: String]? = nil) async -> Bool {
+                              environment: [String: String]? = nil,
+                              diagnosticLog: URL? = AppPaths().root
+                                  .appendingPathComponent("cux-refresh.log")) async -> Bool {
         await CuxShellInvoker.invoke(binary: binary, arguments: ["usage", "refresh"],
-                                     timeout: timeout, environment: environment)
+                                     timeout: timeout, environment: environment,
+                                     diagnosticLog: diagnosticLog)
     }
 }

--- a/Sources/StatusBarCore/Usage/CuxUsageCache.swift
+++ b/Sources/StatusBarCore/Usage/CuxUsageCache.swift
@@ -18,7 +18,14 @@ public enum CuxUsageCache {
     ///
     /// Newer cux versions key entries as "accountUuid|organizationUuid"
     /// rather than a bare organizationUuid; the trailing segment is what
-    /// callers join on, so compound keys are split before storing.
+    /// callers join on, so compound keys are split before storing. cux has
+    /// been observed leaving a stale entry under one key format sitting
+    /// alongside a fresh entry under the other for the same org — old
+    /// writes are never migrated or pruned when the key format changes.
+    /// `[String: Any]` bridged from JSONSerialization iterates in a
+    /// per-process, hash-seed-dependent order, so when two raw keys collide
+    /// on the same orgUuid, the more recent polled_at wins explicitly rather
+    /// than whichever entry the loop happens to visit last.
     public static func parse(_ data: Data) -> [String: UsageSnapshot] {
         guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return [:]
@@ -30,6 +37,7 @@ public enum CuxUsageCache {
                   let snapshot = UsageSnapshot.parse(object: entry, fetchedAt: polledAt)
             else { continue }
             let orgUuid = key.split(separator: "|").last.map(String.init) ?? key
+            if let existing = result[orgUuid], existing.fetchedAt > snapshot.fetchedAt { continue }
             result[orgUuid] = snapshot
         }
         return result

--- a/Tests/StatusBarCoreTests/CuxAccountSwitcherTests.swift
+++ b/Tests/StatusBarCoreTests/CuxAccountSwitcherTests.swift
@@ -80,12 +80,13 @@ struct CuxAccountSwitcherTests {
                                                   ofItemAtPath: script.path)
         }
 
+        let diagnosticLog = dir.appendingPathComponent("diag.log")
         #expect(await CuxAccountSwitcher.invoke(binary: ok.path, arguments: ["switch", "1"],
-                                                 timeout: 5) == true)
+                                                 timeout: 5, diagnosticLog: diagnosticLog) == true)
         #expect(await CuxAccountSwitcher.invoke(binary: bad.path, arguments: ["switch", "1"],
-                                                 timeout: 5) == false)
+                                                 timeout: 5, diagnosticLog: diagnosticLog) == false)
         #expect(await CuxAccountSwitcher.invoke(
             binary: dir.appendingPathComponent("missing").path,
-            arguments: ["switch", "1"], timeout: 5) == false)
+            arguments: ["switch", "1"], timeout: 5, diagnosticLog: diagnosticLog) == false)
     }
 }

--- a/Tests/StatusBarCoreTests/CuxRefresherTests.swift
+++ b/Tests/StatusBarCoreTests/CuxRefresherTests.swift
@@ -86,10 +86,13 @@ struct CuxRefresherTests {
                                                   ofItemAtPath: script.path)
         }
 
-        #expect(await CuxRefresher.invoke(binary: ok.path, timeout: 5) == true)
-        #expect(await CuxRefresher.invoke(binary: bad.path, timeout: 5) == false)
+        let diagnosticLog = dir.appendingPathComponent("diag.log")
+        #expect(await CuxRefresher.invoke(binary: ok.path, timeout: 5,
+                                          diagnosticLog: diagnosticLog) == true)
+        #expect(await CuxRefresher.invoke(binary: bad.path, timeout: 5,
+                                          diagnosticLog: diagnosticLog) == false)
         #expect(await CuxRefresher.invoke(binary: dir.appendingPathComponent("missing").path,
-                                          timeout: 5) == false)
+                                          timeout: 5, diagnosticLog: diagnosticLog) == false)
     }
 
     @Test("invoke kills a hung binary at the timeout")
@@ -115,7 +118,8 @@ struct CuxRefresherTests {
         let started = Date()
         #expect(await CuxRefresher.invoke(
             binary: hang.path, timeout: 0.5,
-            environment: ["HOME": emptyHome.path, "PATH": "/usr/bin:/bin:/usr/sbin:/sbin"]) == false)
+            environment: ["HOME": emptyHome.path, "PATH": "/usr/bin:/bin:/usr/sbin:/sbin"],
+            diagnosticLog: dir.appendingPathComponent("diag.log")) == false)
         #expect(Date().timeIntervalSince(started) < 5)
     }
 }

--- a/Tests/StatusBarCoreTests/CuxShellInvokerTests.swift
+++ b/Tests/StatusBarCoreTests/CuxShellInvokerTests.swift
@@ -70,4 +70,46 @@ struct CuxShellInvokerTests {
         let captured = try String(contentsOf: marker, encoding: .utf8)
         #expect(captured == "hello world")
     }
+
+    @Test("diagnosticLog captures stdout, stderr, and exit code, overwriting on each call")
+    func diagnosticLogCapturesOutput() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cux-shell-invoker-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let script = dir.appendingPathComponent("noisy.sh")
+        try "#!/bin/sh\necho out-marker\necho err-marker 1>&2\nexit 7\n"
+            .write(to: script, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755],
+                                              ofItemAtPath: script.path)
+        // A nonzero exit still returns false from invoke, but the log should
+        // still be written — diagnostics matter most on failure.
+        let diagnosticLog = dir.appendingPathComponent("diag.log")
+
+        let result = await CuxShellInvoker.invoke(
+            binary: script.path, arguments: [], timeout: 5,
+            environment: ["HOME": dir.path, "PATH": "/usr/bin:/bin:/usr/sbin:/sbin"],
+            diagnosticLog: diagnosticLog)
+        #expect(result == false)
+
+        let contents = try String(contentsOf: diagnosticLog, encoding: .utf8)
+        #expect(contents.contains("out-marker"))
+        #expect(contents.contains("err-marker"))
+        #expect(contents.contains("exitCode: 7"))
+
+        // A second, successful call overwrites rather than appends.
+        let quiet = dir.appendingPathComponent("quiet.sh")
+        try "#!/bin/sh\nexit 0\n".write(to: quiet, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755],
+                                              ofItemAtPath: quiet.path)
+        let secondResult = await CuxShellInvoker.invoke(
+            binary: quiet.path, arguments: [], timeout: 5,
+            environment: ["HOME": dir.path, "PATH": "/usr/bin:/bin:/usr/sbin:/sbin"],
+            diagnosticLog: diagnosticLog)
+        #expect(secondResult == true)
+        let overwritten = try String(contentsOf: diagnosticLog, encoding: .utf8)
+        #expect(!overwritten.contains("out-marker"))
+        #expect(overwritten.contains("exitCode: 0"))
+    }
 }

--- a/Tests/StatusBarCoreTests/CuxUsageCacheTests.swift
+++ b/Tests/StatusBarCoreTests/CuxUsageCacheTests.swift
@@ -53,6 +53,38 @@ private let fixture = """
         #expect(cache["acct-ccc|org-ccc"] == nil)
     }
 
+    /// cux has been observed leaving a stale bare-orgUuid-keyed entry (or a
+    /// stale compound accountUuid|orgUuid entry) in the cache alongside a
+    /// fresh entry under the other key format for the same org — old writes
+    /// are never migrated or pruned when the key format changes. `[String:
+    /// Any]` bridged from JSONSerialization iterates in a per-process,
+    /// hash-seed-dependent order, so a naive "last one wins" merge silently
+    /// keeps whichever entry the loop happens to visit last, not necessarily
+    /// the freshest — confirmed against the real ~/.cux/runtime/usage-cache.json,
+    /// where this exact collision made the app display two-day-stale
+    /// percentages non-deterministically across app relaunches. Many
+    /// independently-hashed collisions here make a false pass (by chance
+    /// landing in fresh-last order for every single one) astronomically
+    /// unlikely, so this exercises the real fix rather than relying on luck.
+    @Test func prefersMostRecentEntryAcrossManyKeyCollisions() throws {
+        var object: [String: Any] = [:]
+        var expected: [String: (utilization: Double, fetchedAt: Date)] = [:]
+        for i in 0..<30 {
+            let org = "org-collide-\(i)"
+            let fresh = "2026-07-15T10:00:\(String(format: "%02d", i))Z"
+            let stale = "2026-07-13T04:51:\(String(format: "%02d", i))Z"
+            object[org] = ["five_hour": ["utilization": 11], "polled_at": fresh]
+            object["acct-old-\(i)|\(org)"] = ["five_hour": ["utilization": 99], "polled_at": stale]
+            expected[org] = (11, try #require(ISO8601.parse(fresh)))
+        }
+        let data = try JSONSerialization.data(withJSONObject: object)
+        let cache = CuxUsageCache.parse(data)
+        for (org, exp) in expected {
+            #expect(cache[org]?.fiveHour?.utilization == exp.utilization)
+            #expect(cache[org]?.fetchedAt == exp.fetchedAt)
+        }
+    }
+
     @Test func malformedDataYieldsEmpty() {
         #expect(CuxUsageCache.parse(Data("nope".utf8)).isEmpty)
         #expect(CuxUsageCache.parse(Data("[1,2]".utf8)).isEmpty)


### PR DESCRIPTION
## Summary
- Fixes a usage-accuracy bug: `CuxUsageCache.parse` now prefers the entry with the most recent `polled_at` when a bare-orgUuid key and a compound `accountUuid|orgUuid` key collide on the same org, instead of relying on `[String: Any]`'s non-deterministic iteration order (which could display stale percentages across app relaunches).
- Adds an optional `diagnosticLog` to `CuxShellInvoker.invoke` (wired through `CuxAccountSwitcher`/`CuxRefresher` to `cux-switch.log`/`cux-refresh.log`), capturing command, duration, exit status, and stdout/stderr for the last invocation — built while investigating the Keychain re-prompt issue, kept as standing diagnostics for future cux-related reports.

Note: the actual Keychain re-prompt fix (gating the Keychain fallback read on `cached == nil` in `AppState.token(for:cached:)`) already shipped in #24 and is unrelated to this PR.

## Test plan
- [x] `swift build` — clean
- [x] `swift test` — full suite passes (185 tests), including new `prefersMostRecentEntryAcrossManyKeyCollisions` and `diagnosticLogCapturesOutput` regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)