### PR TITLE
Log which token-resolution branch fires, to catch the intermittent Keychain re-prompt

### DIFF
--- a/Sources/ClaudeStatusBar/AppState.swift
+++ b/Sources/ClaudeStatusBar/AppState.swift
@@ -230,38 +230,33 @@ final class AppState {
     /// Pairs each account with its token and, for tokenless cux slots, the
     /// snapshot cux itself polled into ~/.cux/runtime/usage-cache.json
     /// (joined on organizationUuid). Reads the cache file once per refresh.
+    ///
+    /// Token resolution itself lives in StatusBarCore's `TokenResolution` (see
+    /// its doc comment for the isActive/cached gating this replays). Each
+    /// account's decision is additionally logged to `token-resolution.log`
+    /// under `paths.root` — there to give the still-unexplained intermittent
+    /// Keychain re-prompt real evidence: if the log from the exact cycle when
+    /// the prompt fired shows `tokenSource=keychainFallback` alongside an
+    /// unexpectedly nil orgUuid or false cuxCacheHit for an account cux has
+    /// already cached, that confirms a transient read racing cux's own
+    /// rewrite of oauth.json / usage-cache.json, rather than leaving it a
+    /// guess. Never logs a token value.
     private func usageInputs(
         _ accounts: [Account]
     ) -> [(account: Account, token: String?, cached: UsageSnapshot?)] {
         let cache = CuxUsageCache.load(
             file: cuxRoot.appendingPathComponent("runtime/usage-cache.json"))
-        return accounts.map { account in
+        var diagnostics: [TokenResolutionDiagnostics.Entry] = []
+        let result = accounts.map { account -> (account: Account, token: String?, cached: UsageSnapshot?) in
             let cached = account.organizationUuid.flatMap { cache[$0] }
-            return (account, token(for: account, cached: cached), cached)
+            let (token, source) = TokenResolution.resolve(account: account, cached: cached)
+            diagnostics.append(.init(accountId: account.id, isActive: account.isActive,
+                                     organizationUuid: account.organizationUuid,
+                                     cacheHit: cached != nil, source: source))
+            return (account, token, cached)
         }
-    }
-
-    /// Token is read at fetch time only, kept in a local, never stored or
-    /// logged. cux v0.2.11+ keeps the real token only in the Keychain, never
-    /// in a slot's oauth.json — but cux swaps just the *active* slot's token
-    /// into the Keychain, so the fallback is gated on `isActive` to avoid
-    /// misattributing that token to other, inactive accounts.
-    ///
-    /// Also gated on `cached == nil`: cux rewrites the shared Keychain item
-    /// on every `cux switch`, which resets macOS's "Always Allow" grant for
-    /// it, so touching the Keychain is what actually re-prompts the user —
-    /// not the switch itself. A cux-cache snapshot (even a stale one) is
-    /// already enough for UsageStore to display usage, so once cux has
-    /// cached anything for this account's org there's nothing left for the
-    /// Keychain read to buy beyond a fresher percentage, at the cost of a
-    /// prompt on every poll cycle. Only fall back to the Keychain when cux
-    /// hasn't cached this org at all yet (e.g. a brand-new slot).
-    private func token(for account: Account, cached: UsageSnapshot?) -> String? {
-        if let data = try? Data(contentsOf: account.oauthURL),
-           let token = AccountDiscovery.accessToken(from: data) {
-            return token
-        }
-        guard account.isActive, cached == nil else { return nil }
-        return AccountDiscovery.keychainAccessToken()
+        TokenResolutionDiagnostics.write(
+            diagnostics, to: paths.root.appendingPathComponent("token-resolution.log"))
+        return result
     }
 }

--- a/Sources/StatusBarCore/Accounts/TokenResolution.swift
+++ b/Sources/StatusBarCore/Accounts/TokenResolution.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Which branch of the token-resolution decision produced a token — tracked
+/// so a poll cycle can log which one fired instead of just the resulting
+/// token. The Keychain-fallback branch firing when `cached` unexpectedly
+/// reads back nil for an account cux has already cached is the leading
+/// hypothesis for the still-unexplained intermittent Keychain re-prompt.
+public enum TokenSource: String, Sendable {
+    case oauthFile
+    case keychainFallback
+    case none
+}
+
+/// Extracted from AppState.token(for:cached:) so the same decision can be
+/// both made and observed: production needs the token, diagnostics need to
+/// know which branch produced it, without ever logging the token itself.
+public enum TokenResolution {
+    /// cux v0.2.11+ keeps the real token only in the Keychain, never in a
+    /// slot's oauth.json — but cux swaps just the *active* slot's token into
+    /// the Keychain, so the fallback is gated on `isActive` to avoid
+    /// misattributing that token to other, inactive accounts. It's further
+    /// gated on `cached == nil`: cux rewrites the shared Keychain item on
+    /// every `cux switch`, resetting macOS's "Always Allow" grant for it, so
+    /// touching the Keychain is what actually re-prompts the user. Once cux
+    /// has cached anything for this account's org there's nothing left for
+    /// the Keychain read to buy beyond a fresher percentage, at the cost of
+    /// a prompt on every poll cycle.
+    public static func resolve(
+        account: Account,
+        cached: UsageSnapshot?,
+        oauthData: (URL) -> Data? = { try? Data(contentsOf: $0) },
+        keychainAccessToken: () -> String? = { AccountDiscovery.keychainAccessToken() }
+    ) -> (token: String?, source: TokenSource) {
+        if let data = oauthData(account.oauthURL),
+           let token = AccountDiscovery.accessToken(from: data) {
+            return (token, .oauthFile)
+        }
+        guard account.isActive, cached == nil else { return (nil, .none) }
+        return (keychainAccessToken(), .keychainFallback)
+    }
+}
+
+/// One poll cycle's token-resolution decisions, written to give the
+/// still-unexplained intermittent Keychain re-prompt real evidence: if
+/// `tokenSource=keychainFallback` shows up here right when the prompt fires,
+/// and `orgUuid` or `cuxCacheHit` is unexpectedly nil/false for an account
+/// cux has already cached, that confirms the race hypothesis (a transient
+/// nil from a read racing cux's own rewrite of oauth.json or
+/// usage-cache.json) instead of leaving it a guess. Never includes a token
+/// value, per this app's rule that tokens are read at request time only and
+/// never logged.
+public enum TokenResolutionDiagnostics {
+    public struct Entry: Sendable {
+        public let accountId: String
+        public let isActive: Bool
+        public let organizationUuid: String?
+        public let cacheHit: Bool
+        public let source: TokenSource
+
+        public init(accountId: String, isActive: Bool, organizationUuid: String?,
+                    cacheHit: Bool, source: TokenSource) {
+            self.accountId = accountId
+            self.isActive = isActive
+            self.organizationUuid = organizationUuid
+            self.cacheHit = cacheHit
+            self.source = source
+        }
+    }
+
+    static func format(_ entries: [Entry], now: Date) -> String {
+        var lines = ["timestamp: \(ISO8601DateFormatter().string(from: now))"]
+        lines += entries.map { entry in
+            "\(entry.accountId) isActive=\(entry.isActive) "
+                + "orgUuid=\(entry.organizationUuid ?? "nil") "
+                + "cuxCacheHit=\(entry.cacheHit) tokenSource=\(entry.source.rawValue)"
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    /// Overwrites `url` (not append) — only the most recent poll cycle's
+    /// decisions matter, mirroring CuxShellInvoker's diagnosticLog. Silently
+    /// no-ops on filesystem errors: diagnostics must never be able to fail a
+    /// poll cycle.
+    public static func write(_ entries: [Entry], to url: URL, now: Date = Date()) {
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? format(entries, now: now).write(to: url, atomically: true, encoding: .utf8)
+    }
+}

--- a/Tests/StatusBarCoreTests/TokenResolutionTests.swift
+++ b/Tests/StatusBarCoreTests/TokenResolutionTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+@testable import StatusBarCore
+
+private func account(id: String = "acct", isActive: Bool = false) -> Account {
+    Account(id: id, alias: nil, email: nil, slot: 1, isActive: isActive,
+            oauthURL: URL(fileURLWithPath: "/dev/null"))
+}
+
+private func snapshot() -> UsageSnapshot {
+    UsageSnapshot(fiveHour: nil, sevenDay: nil, fetchedAt: Date(timeIntervalSinceReferenceDate: 0))
+}
+
+@Suite("TokenResolution")
+struct TokenResolutionTests {
+    @Test("returns the oauth-file token when present, regardless of isActive or cached")
+    func resolvesFromOauthFile() {
+        let (token, source) = TokenResolution.resolve(
+            account: account(isActive: false), cached: snapshot(),
+            oauthData: { _ in Data(#"{"claudeAiOauth":{"accessToken":"tok"}}"#.utf8) },
+            keychainAccessToken: { Issue.record("should not consult Keychain"); return nil })
+        #expect(token == "tok")
+        #expect(source == .oauthFile)
+    }
+
+    @Test("returns none when oauth is empty and the account isn't active")
+    func returnsNoneWhenInactive() {
+        let (token, source) = TokenResolution.resolve(
+            account: account(isActive: false), cached: nil,
+            oauthData: { _ in nil },
+            keychainAccessToken: { Issue.record("should not consult Keychain"); return nil })
+        #expect(token == nil)
+        #expect(source == .none)
+    }
+
+    @Test("returns none when oauth is empty, active, but a cached snapshot already exists")
+    func returnsNoneWhenCached() {
+        let (token, source) = TokenResolution.resolve(
+            account: account(isActive: true), cached: snapshot(),
+            oauthData: { _ in nil },
+            keychainAccessToken: { Issue.record("should not consult Keychain"); return nil })
+        #expect(token == nil)
+        #expect(source == .none)
+    }
+
+    @Test("falls back to the Keychain only when active with no cached snapshot")
+    func fallsBackToKeychain() {
+        let (token, source) = TokenResolution.resolve(
+            account: account(isActive: true), cached: nil,
+            oauthData: { _ in nil },
+            keychainAccessToken: { "keychain-tok" })
+        #expect(token == "keychain-tok")
+        #expect(source == .keychainFallback)
+    }
+}
+
+@Suite("TokenResolutionDiagnostics")
+struct TokenResolutionDiagnosticsTests {
+    @Test("formats one line per entry with a leading timestamp, never including a token value")
+    func formatsEntries() {
+        let now = Date(timeIntervalSinceReferenceDate: 1_000)
+        let text = TokenResolutionDiagnostics.format(
+            [
+                .init(accountId: "slot-1", isActive: true, organizationUuid: "org-aaa",
+                      cacheHit: false, source: .keychainFallback),
+                .init(accountId: "slot-2", isActive: false, organizationUuid: nil,
+                      cacheHit: true, source: .none),
+            ], now: now)
+        #expect(text.hasPrefix("timestamp: "))
+        #expect(text.contains("slot-1 isActive=true orgUuid=org-aaa cuxCacheHit=false tokenSource=keychainFallback"))
+        #expect(text.contains("slot-2 isActive=false orgUuid=nil cuxCacheHit=true tokenSource=none"))
+    }
+
+    @Test("write overwrites the file on each call rather than appending")
+    func writeOverwrites() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("token-resolution-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("token-resolution.log")
+
+        TokenResolutionDiagnostics.write(
+            [.init(accountId: "slot-1", isActive: true, organizationUuid: "org-aaa",
+                   cacheHit: false, source: .keychainFallback)],
+            to: file, now: Date(timeIntervalSinceReferenceDate: 0))
+        let first = try String(contentsOf: file, encoding: .utf8)
+        #expect(first.contains("slot-1"))
+
+        TokenResolutionDiagnostics.write(
+            [.init(accountId: "slot-2", isActive: false, organizationUuid: nil,
+                   cacheHit: true, source: .oauthFile)],
+            to: file, now: Date(timeIntervalSinceReferenceDate: 1))
+        let second = try String(contentsOf: file, encoding: .utf8)
+        #expect(!second.contains("slot-1"))
+        #expect(second.contains("slot-2"))
+    }
+
+    @Test("write creates intermediate directories that don't exist yet")
+    func writeCreatesDirectories() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("token-resolution-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("nested/token-resolution.log")
+
+        TokenResolutionDiagnostics.write([], to: file)
+        #expect(FileManager.default.fileExists(atPath: file.path))
+    }
+}


### PR DESCRIPTION
## Summary
- User reports occasionally getting a Keychain permission prompt correlated with hitting a rate limit, despite PR #24's isActive/cached gating and PR #25's diagnostics.
- Extracts `AppState`'s token(for:cached:) decision into `StatusBarCore.TokenResolution` so the same decision can be made and observed, then logs each account's resolution (id, isActive, orgUuid, cux-cache-hit, which branch fired) to `token-resolution.log` on every poll cycle.
- Never logs a token value — only metadata about which branch produced one.
- This is diagnostic instrumentation only, not a fix: the goal is to capture the exact poll cycle when the prompt next fires, to confirm or rule out the leading hypothesis (a transient nil in `organizationUuid`/cux-cache lookup racing cux's own file rewrites).

## Test plan
- [x] `swift test` — all 192 tests pass, including new `TokenResolutionTests` (4 tests) and `TokenResolutionDiagnosticsTests` (3 tests)
- [ ] Ship this build, reproduce the intermittent prompt, inspect `token-resolution.log` from that poll cycle

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>