### PR TITLE
Bump version to 0.1.4

### DIFF
--- a/Sources/StatusBarCore/StatusBarCore.swift
+++ b/Sources/StatusBarCore/StatusBarCore.swift
@@ -1,3 +1,3 @@
 public enum StatusBarCoreInfo {
-    public static let version = "0.1.3"
+    public static let version = "0.1.4"
 }

--- a/Tests/StatusBarCoreTests/PackageTests.swift
+++ b/Tests/StatusBarCoreTests/PackageTests.swift
@@ -2,5 +2,5 @@ import Testing
 @testable import StatusBarCore
 
 @Test func versionIsSet() {
-    #expect(StatusBarCoreInfo.version == "0.1.3")
+    #expect(StatusBarCoreInfo.version == "0.1.4")
 }

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-VERSION="${VERSION:-0.1.3}"
+VERSION="${VERSION:-0.1.4}"
 APP="dist/ClaudeStatusBar.app"
 BIN=".build/release"
 


### PR DESCRIPTION
## Summary
- Version bump 0.1.3 → 0.1.4 to match the next release tag, following the same pattern as the previous bump (commit 189d812).
- Ships the token-resolution diagnostic logging and CuxUsageCache key-collision fix (#26).

## Test plan
- [x] `swift test` — 192/192 passing