### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/Sources/StatusBarCore/StatusBarCore.swift
+++ b/Sources/StatusBarCore/StatusBarCore.swift
@@ -1,3 +1,3 @@
 public enum StatusBarCoreInfo {
-    public static let version = "0.1.4"
+    public static let version = "0.1.5"
 }

--- a/Tests/StatusBarCoreTests/PackageTests.swift
+++ b/Tests/StatusBarCoreTests/PackageTests.swift
@@ -2,5 +2,5 @@ import Testing
 @testable import StatusBarCore
 
 @Test func versionIsSet() {
-    #expect(StatusBarCoreInfo.version == "0.1.4")
+    #expect(StatusBarCoreInfo.version == "0.1.5")
 }

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-VERSION="${VERSION:-0.1.4}"
+VERSION="${VERSION:-0.1.5}"
 APP="dist/ClaudeStatusBar.app"
 BIN=".build/release"
 


### PR DESCRIPTION
Bump version to 0.1.5 ahead of tagging the release, following the same pattern as the prior 0.1.1–0.1.4 bumps (#14, #20, #23, #27).

## Test plan
- [x] `make test` — 232/232 passing