### PR TITLE
fix: self-heal live-credentials Keychain ACL on every launch

### DIFF
--- a/Sources/ClaudeStatusBar/AppState.swift
+++ b/Sources/ClaudeStatusBar/AppState.swift
@@ -71,6 +71,10 @@ final class AppState {
         try? paths.ensureDirs()
         usageStore.loadCache()
         accounts = resolveAccounts()
+        // Re-assert the live credentials' Keychain ACL once per launch so an
+        // account that has never completed a successful switch (the only
+        // path that used to fix this) still stops re-prompting for access.
+        _ = LiveCredentialSelfHeal.run(diagnosticLog: paths.root.appendingPathComponent("native-switch.log"))
         reaggregate()
 
         watcher = DirectoryWatcher(url: paths.sessionsDir) { [weak self] in

--- a/Sources/StatusBarCore/Accounts/LiveCredentialSelfHeal.swift
+++ b/Sources/StatusBarCore/Accounts/LiveCredentialSelfHeal.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Re-asserts the live `"Claude Code-credentials"` Keychain item's ACL so it
+/// trusts this app, independent of `NativeAccountSwitcher.switchTo()` ever
+/// succeeding. `LiveCredentialWriter.write`'s ACL fix (see its doc comment)
+/// used to only run as a side effect of a successful switch — an account
+/// whose only switch attempt fails (e.g. a migrated cux slot with no vault
+/// backup) never benefited from it, and kept hitting macOS's Keychain
+/// prompt on every `TokenResolution` `keychainFallback` read instead.
+///
+/// Meant to run once per app launch, not on a timer: `SecAccessCreate`
+/// builds a fresh access object on every call, and re-applying an ACL resets
+/// any "Always Allow" grant already given for it — calling this every poll
+/// cycle would trade one re-prompt problem for a smaller but still
+/// recurring one.
+public enum LiveCredentialSelfHeal {
+    public static func run(
+        diagnosticLog: URL? = nil,
+        read: () -> Data? = { LiveCredentialWriter.read() },
+        write: (Data, [String]) -> Bool = { data, paths in LiveCredentialWriter.write(data, trustedPaths: paths) },
+        trustedPaths: () -> [String] = {
+            LiveCredentialWriter.trustedPaths(thisAppPath: Bundle.main.bundlePath,
+                                              claudePath: LiveCredentialWriter.resolvedClaudePath())
+        }
+    ) -> Bool {
+        guard let data = read() else {
+            writeDiagnostic("self-heal ACL skipped: no live credentials found", to: diagnosticLog)
+            return false
+        }
+        let succeeded = write(data, trustedPaths())
+        writeDiagnostic(succeeded ? "self-heal ACL succeeded" : "self-heal ACL failed: write rejected",
+                        to: diagnosticLog)
+        return succeeded
+    }
+
+    private static func writeDiagnostic(_ message: String, to log: URL?) {
+        guard let log else { return }
+        let line = "\(Date()) \(message)\n"
+        guard let data = line.data(using: .utf8) else { return }
+        if let handle = try? FileHandle(forWritingTo: log) {
+            handle.seekToEndOfFile()
+            handle.write(data)
+            try? handle.close()
+        } else {
+            try? data.write(to: log)
+        }
+    }
+}

--- a/Tests/StatusBarCoreTests/LiveCredentialSelfHealTests.swift
+++ b/Tests/StatusBarCoreTests/LiveCredentialSelfHealTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+@testable import StatusBarCore
+
+@Suite struct LiveCredentialSelfHealTests {
+    @Test func writesCurrentLiveCredentialsBackWithTrustedPaths() {
+        var captured: (Data, [String])?
+        let ok = LiveCredentialSelfHeal.run(
+            read: { Data("current-creds".utf8) },
+            write: { data, paths in captured = (data, paths); return true },
+            trustedPaths: { ["/Applications/ClaudeStatusBar.app", "/opt/homebrew/bin/claude"] }
+        )
+
+        #expect(ok)
+        #expect(captured?.0 == Data("current-creds".utf8))
+        #expect(captured?.1 == ["/Applications/ClaudeStatusBar.app", "/opt/homebrew/bin/claude"])
+    }
+
+    @Test func noOpWhenNoLiveCredentialsExistYet() {
+        var writeCalled = false
+        let ok = LiveCredentialSelfHeal.run(
+            read: { nil },
+            write: { _, _ in writeCalled = true; return true },
+            trustedPaths: { [] }
+        )
+
+        #expect(ok == false)
+        #expect(writeCalled == false)
+    }
+
+    @Test func returnsFalseWhenWriteFails() {
+        let ok = LiveCredentialSelfHeal.run(
+            read: { Data("current-creds".utf8) },
+            write: { _, _ in false },
+            trustedPaths: { [] }
+        )
+
+        #expect(ok == false)
+    }
+
+    @Test func appendsSuccessDiagnostic() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let log = dir.appendingPathComponent("native-switch.log")
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        _ = LiveCredentialSelfHeal.run(
+            diagnosticLog: log,
+            read: { Data("creds".utf8) },
+            write: { _, _ in true },
+            trustedPaths: { [] }
+        )
+
+        let contents = try String(contentsOf: log, encoding: .utf8)
+        #expect(contents.contains("self-heal ACL succeeded"))
+    }
+
+    @Test func appendsFailureDiagnosticWhenWriteFails() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let log = dir.appendingPathComponent("native-switch.log")
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        _ = LiveCredentialSelfHeal.run(
+            diagnosticLog: log,
+            read: { Data("creds".utf8) },
+            write: { _, _ in false },
+            trustedPaths: { [] }
+        )
+
+        let contents = try String(contentsOf: log, encoding: .utf8)
+        #expect(contents.contains("self-heal ACL failed"))
+    }
+}


### PR DESCRIPTION
## Summary
- After v0.1.5 shipped native account switching, a user reported the app repeatedly re-prompting for Keychain access even though it "seems to work."
- Root cause: `LiveCredentialWriter.write`'s ACL fix (the only code path that sets the Keychain item's ACL to trust both `claude` and this app) previously only ran as a side effect of a **successful** `NativeAccountSwitcher.switchTo()` call. An account whose only switch attempt fails before reaching that step (e.g. a migrated cux slot with no vault backup) never gets the ACL corrected — so its `keychainFallback` token reads keep hitting an item that never trusted this app, triggering a Keychain prompt on every poll cycle.
- `LiveCredentialSelfHeal.run()` re-asserts the ACL unconditionally at app startup, independent of whether any switch has ever succeeded. It runs once per launch (not per poll cycle) since `SecAccessCreate` builds a fresh access object each call and repeated re-application would itself reset "Always Allow" grants.

## Test plan
- [x] `swift test --filter LiveCredentialSelfHealTests` — 5/5 new tests pass
- [x] `swift test` — full suite, 237/237 pass
- [x] `swift build` — clean build with the new `AppState.start()` wiring