### PR TITLE
Bump version to 0.1.6 so the next tag matches the binary

### DIFF
--- a/Sources/StatusBarCore/StatusBarCore.swift
+++ b/Sources/StatusBarCore/StatusBarCore.swift
@@ -1,3 +1,3 @@
 public enum StatusBarCoreInfo {
-    public static let version = "0.1.5"
+    public static let version = "0.1.6"
 }

--- a/Tests/StatusBarCoreTests/PackageTests.swift
+++ b/Tests/StatusBarCoreTests/PackageTests.swift
@@ -2,5 +2,5 @@ import Testing
 @testable import StatusBarCore
 
 @Test func versionIsSet() {
-    #expect(StatusBarCoreInfo.version == "0.1.5")
+    #expect(StatusBarCoreInfo.version == "0.1.6")
 }

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-VERSION="${VERSION:-0.1.5}"
+VERSION="${VERSION:-0.1.6}"
 APP="dist/ClaudeStatusBar.app"
 BIN=".build/release"
 


### PR DESCRIPTION
## Summary
- Patch release containing the Keychain ACL self-heal fix (#30) merged since v0.1.5.
- Bumps the version string in the three places it's hardcoded, ahead of tagging v0.1.6.

## Test plan
- [x] `swift test --filter versionIsSet` passes with the new version string