### PR TITLE
Skip self-heal ACL rewrite when already trusted

### DIFF
--- a/Sources/StatusBarCore/Accounts/LiveCredentialSelfHeal.swift
+++ b/Sources/StatusBarCore/Accounts/LiveCredentialSelfHeal.swift
@@ -13,9 +13,17 @@ import Foundation
 /// any "Always Allow" grant already given for it — calling this every poll
 /// cycle would trade one re-prompt problem for a smaller but still
 /// recurring one.
+///
+/// Running once per launch still resets that grant once per launch, so
+/// frequent relaunches reproduce the same re-prompt at a lower frequency.
+/// `isTrusted` probes (non-interactively, via
+/// `LiveCredentialWriter.isAlreadyTrusted`) whether the ACL already covers
+/// this app before rewriting it — when it does, `read`/`write` are skipped
+/// entirely and the existing "Always Allow" grant survives untouched.
 public enum LiveCredentialSelfHeal {
     public static func run(
         diagnosticLog: URL? = nil,
+        isTrusted: () -> Bool = { LiveCredentialWriter.isAlreadyTrusted() },
         read: () -> Data? = { LiveCredentialWriter.read() },
         write: (Data, [String]) -> Bool = { data, paths in LiveCredentialWriter.write(data, trustedPaths: paths) },
         trustedPaths: () -> [String] = {
@@ -23,6 +31,10 @@ public enum LiveCredentialSelfHeal {
                                               claudePath: LiveCredentialWriter.resolvedClaudePath())
         }
     ) -> Bool {
+        if isTrusted() {
+            writeDiagnostic("self-heal ACL skipped: already trusted", to: diagnosticLog)
+            return true
+        }
         guard let data = read() else {
             writeDiagnostic("self-heal ACL skipped: no live credentials found", to: diagnosticLog)
             return false

--- a/Sources/StatusBarCore/Accounts/LiveCredentialWriter.swift
+++ b/Sources/StatusBarCore/Accounts/LiveCredentialWriter.swift
@@ -14,6 +14,32 @@ public enum LiveCredentialWriter {
         reader(service)
     }
 
+    /// Non-interactive probe: can the current process already read the live
+    /// item without macOS needing to show a Keychain prompt? Uses
+    /// `kSecUseAuthenticationUIFail` so an untrusted caller gets
+    /// `errSecInteractionNotAllowed` back instead of a dialog.
+    ///
+    /// `LiveCredentialSelfHeal` calls this before touching the ACL: skipping
+    /// the rewrite when the app is already trusted avoids resetting an
+    /// "Always Allow" grant that's already in place (see
+    /// `LiveCredentialSelfHeal`'s doc comment on why `SecAccessCreate` makes
+    /// that rewrite itself destructive).
+    public static func isAlreadyTrusted(prober: (String) -> Bool = defaultTrustProbe) -> Bool {
+        prober(service)
+    }
+
+    public static func defaultTrustProbe(service: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrLabel as String: service,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecUseAuthenticationUI as String: kSecUseAuthenticationUIFail,
+        ]
+        var item: CFTypeRef?
+        return SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess
+    }
+
     public static func write(
         _ data: Data,
         trustedPaths: [String],

--- a/Tests/StatusBarCoreTests/LiveCredentialSelfHealTests.swift
+++ b/Tests/StatusBarCoreTests/LiveCredentialSelfHealTests.swift
@@ -6,6 +6,7 @@ import Testing
     @Test func writesCurrentLiveCredentialsBackWithTrustedPaths() {
         var captured: (Data, [String])?
         let ok = LiveCredentialSelfHeal.run(
+            isTrusted: { false },
             read: { Data("current-creds".utf8) },
             write: { data, paths in captured = (data, paths); return true },
             trustedPaths: { ["/Applications/ClaudeStatusBar.app", "/opt/homebrew/bin/claude"] }
@@ -19,6 +20,7 @@ import Testing
     @Test func noOpWhenNoLiveCredentialsExistYet() {
         var writeCalled = false
         let ok = LiveCredentialSelfHeal.run(
+            isTrusted: { false },
             read: { nil },
             write: { _, _ in writeCalled = true; return true },
             trustedPaths: { [] }
@@ -30,6 +32,7 @@ import Testing
 
     @Test func returnsFalseWhenWriteFails() {
         let ok = LiveCredentialSelfHeal.run(
+            isTrusted: { false },
             read: { Data("current-creds".utf8) },
             write: { _, _ in false },
             trustedPaths: { [] }
@@ -46,6 +49,7 @@ import Testing
 
         _ = LiveCredentialSelfHeal.run(
             diagnosticLog: log,
+            isTrusted: { false },
             read: { Data("creds".utf8) },
             write: { _, _ in true },
             trustedPaths: { [] }
@@ -63,6 +67,7 @@ import Testing
 
         _ = LiveCredentialSelfHeal.run(
             diagnosticLog: log,
+            isTrusted: { false },
             read: { Data("creds".utf8) },
             write: { _, _ in false },
             trustedPaths: { [] }
@@ -70,5 +75,38 @@ import Testing
 
         let contents = try String(contentsOf: log, encoding: .utf8)
         #expect(contents.contains("self-heal ACL failed"))
+    }
+
+    @Test func skipsReadAndWriteWhenAlreadyTrusted() {
+        var readCalled = false
+        var writeCalled = false
+        let ok = LiveCredentialSelfHeal.run(
+            isTrusted: { true },
+            read: { readCalled = true; return Data("creds".utf8) },
+            write: { _, _ in writeCalled = true; return true },
+            trustedPaths: { [] }
+        )
+
+        #expect(ok)
+        #expect(readCalled == false)
+        #expect(writeCalled == false)
+    }
+
+    @Test func appendsSkippedDiagnosticWhenAlreadyTrusted() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let log = dir.appendingPathComponent("native-switch.log")
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        _ = LiveCredentialSelfHeal.run(
+            diagnosticLog: log,
+            isTrusted: { true },
+            read: { Data("creds".utf8) },
+            write: { _, _ in true },
+            trustedPaths: { [] }
+        )
+
+        let contents = try String(contentsOf: log, encoding: .utf8)
+        #expect(contents.contains("self-heal ACL skipped: already trusted"))
     }
 }

--- a/Tests/StatusBarCoreTests/LiveCredentialWriterTests.swift
+++ b/Tests/StatusBarCoreTests/LiveCredentialWriterTests.swift
@@ -57,6 +57,19 @@ import Testing
         #expect(path == nil)
     }
 
+    // MARK: - isAlreadyTrusted
+
+    @Test func isAlreadyTrustedDelegatesToInjectedProber() {
+        let result = LiveCredentialWriter.isAlreadyTrusted(prober: { service in
+            service == LiveCredentialWriter.service
+        })
+        #expect(result)
+    }
+
+    @Test func isAlreadyTrustedReturnsFalseWhenProberFails() {
+        #expect(LiveCredentialWriter.isAlreadyTrusted(prober: { _ in false }) == false)
+    }
+
     // MARK: - performWrite
 
     @Test func performWriteUpdatesInPlaceWhenItemExists() {


### PR DESCRIPTION
## Summary
- v0.1.6's `LiveCredentialSelfHeal` re-asserts the live Keychain item's ACL once per app launch, but `SecAccessCreate` resets any existing "Always Allow" grant on *every* call — so users who relaunch the app often kept getting re-prompted, just less often than before v0.1.6.
- `LiveCredentialWriter.isAlreadyTrusted()` now probes non-interactively (`kSecUseAuthenticationUIFail`, no dialog shown) whether the app is already trusted before touching the ACL.
- `LiveCredentialSelfHeal.run` checks this first and skips `read`/`write` entirely when already trusted, so an existing grant survives across relaunches. The prompt now occurs once per genuine trust loss (fresh install, or an external ACL reset) rather than once per launch.

## Test plan
- [x] `swift test` — full suite passes (241/241)
- [x] `swift test --filter LiveCredential` — 21/21, including new coverage for the trust-check short-circuit (skip path, diagnostic message, probe delegation)
- [ ] Manual: build `dist/ClaudeStatusBar.app`, grant Keychain access once, relaunch repeatedly, confirm no further prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)