### PR TITLE
Bump version to 0.1.7

### DIFF
--- a/Sources/StatusBarCore/StatusBarCore.swift
+++ b/Sources/StatusBarCore/StatusBarCore.swift
@@ -1,3 +1,3 @@
 public enum StatusBarCoreInfo {
-    public static let version = "0.1.6"
+    public static let version = "0.1.7"
 }

--- a/Tests/StatusBarCoreTests/PackageTests.swift
+++ b/Tests/StatusBarCoreTests/PackageTests.swift
@@ -2,5 +2,5 @@ import Testing
 @testable import StatusBarCore
 
 @Test func versionIsSet() {
-    #expect(StatusBarCoreInfo.version == "0.1.6")
+    #expect(StatusBarCoreInfo.version == "0.1.7")
 }

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-VERSION="${VERSION:-0.1.6}"
+VERSION="${VERSION:-0.1.7}"
 APP="dist/ClaudeStatusBar.app"
 BIN=".build/release"
 


### PR DESCRIPTION
## Summary
- Bumps version to 0.1.7 so the next tag matches the binary, following the fix in #32 (Keychain self-heal no longer resets an existing "Always Allow" grant on every app launch).

## Test plan
- [x] `swift test --filter versionIsSet` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)