### PR TITLE
Bump version to 0.1.8 so the next tag matches the binary

### DIFF
--- a/Sources/StatusBarCore/StatusBarCore.swift
+++ b/Sources/StatusBarCore/StatusBarCore.swift
@@ -1,3 +1,3 @@
 public enum StatusBarCoreInfo {
-    public static let version = "0.1.7"
+    public static let version = "0.1.8"
 }

--- a/Tests/StatusBarCoreTests/PackageTests.swift
+++ b/Tests/StatusBarCoreTests/PackageTests.swift
@@ -2,5 +2,5 @@ import Testing
 @testable import StatusBarCore
 
 @Test func versionIsSet() {
-    #expect(StatusBarCoreInfo.version == "0.1.7")
+    #expect(StatusBarCoreInfo.version == "0.1.8")
 }

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-VERSION="${VERSION:-0.1.7}"
+VERSION="${VERSION:-0.1.8}"
 APP="dist/ClaudeStatusBar.app"
 BIN=".build/release"
 


### PR DESCRIPTION
Version bump for the 0.1.8 release, following PR #34 (cux removal + reactive per-poll-cycle Keychain self-heal).

## Test plan
- [x] `swift build`
- [x] `swift test`