### PR TITLE
Bump version to 0.1.9

### DIFF
--- a/Sources/StatusBarCore/StatusBarCore.swift
+++ b/Sources/StatusBarCore/StatusBarCore.swift
@@ -1,3 +1,3 @@
 public enum StatusBarCoreInfo {
-    public static let version = "0.1.8"
+    public static let version = "0.1.9"
 }

--- a/Tests/StatusBarCoreTests/PackageTests.swift
+++ b/Tests/StatusBarCoreTests/PackageTests.swift
@@ -2,5 +2,5 @@ import Testing
 @testable import StatusBarCore
 
 @Test func versionIsSet() {
-    #expect(StatusBarCoreInfo.version == "0.1.8")
+    #expect(StatusBarCoreInfo.version == "0.1.9")
 }

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-VERSION="${VERSION:-0.1.8}"
+VERSION="${VERSION:-0.1.9}"
 APP="dist/ClaudeStatusBar.app"
 BIN=".build/release"
 


### PR DESCRIPTION
Bumps the version string ahead of tagging v0.1.9, following the same pattern as prior bump PRs (#31, #33, #35).

- `Sources/StatusBarCore/StatusBarCore.swift`
- `Tests/StatusBarCoreTests/PackageTests.swift`
- `scripts/make-app.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)