### PR TITLE
Stop account switching from resetting Keychain ACL trust

### DIFF
--- a/Sources/StatusBarCore/Accounts/LiveCredentialWriter.swift
+++ b/Sources/StatusBarCore/Accounts/LiveCredentialWriter.swift
@@ -114,6 +114,58 @@ public enum LiveCredentialWriter {
         return add(addAttributes as CFDictionary, nil) == errSecSuccess
     }
 
+    public static func writeValue(
+        _ data: Data,
+        writer: (Data, String) -> Bool = defaultWriteValue
+    ) -> Bool {
+        writer(data, service)
+    }
+
+    public static func defaultWriteValue(data: Data, service: String) -> Bool {
+        performWriteValue(data: data, service: service, account: NSUserName())
+    }
+
+    /// Value-only update — never touches `kSecAttrAccess`, unlike
+    /// `performWrite`. Account switching only needs to change the
+    /// credential bytes; rewriting the ACL on every switch is what resets
+    /// an existing "Always Allow" grant (see `performWrite`'s doc comment).
+    /// `LiveCredentialSelfHeal` owns re-asserting the ACL, gated behind its
+    /// own non-interactive trust probe on a deliberately bounded cadence —
+    /// this path stays out of that business entirely.
+    static func performWriteValue(
+        data: Data,
+        service: String,
+        account: String,
+        update: (CFDictionary, CFDictionary) -> OSStatus = SecItemUpdate,
+        add: (CFDictionary, UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus = SecItemAdd
+    ) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrLabel as String: service,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+
+        let newAttributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+        ]
+
+        let updateStatus = update(query as CFDictionary, newAttributes as CFDictionary)
+        if updateStatus == errSecSuccess {
+            return true
+        }
+        guard updateStatus == errSecItemNotFound else {
+            return false
+        }
+
+        var addAttributes = query
+        for (key, value) in newAttributes {
+            addAttributes[key] = value
+        }
+        return add(addAttributes as CFDictionary, nil) == errSecSuccess
+    }
+
     /// Non-nil entries only — `claudePath` is nil when `claude`'s binary
     /// can't be resolved (see `resolvedClaudePath`), in which case the live
     /// item's ACL falls back to app-only trust.
@@ -133,5 +185,86 @@ public enum LiveCredentialWriter {
         isExecutable: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
     ) -> String? {
         candidates.first(where: isExecutable)
+    }
+
+    /// Result of running a fixed-path system binary via `defaultRun`.
+    public struct ShellResult {
+        public let stdout: String
+        public let stderr: String
+        public let exitCode: Int32
+    }
+
+    /// Runs `binary arguments` directly (no shell) and captures both stdout
+    /// and stderr. Modeled on `InteractiveShellRunner.captureOutput`'s
+    /// `Process`/`Pipe`/`withCheckedContinuation` idiom, but simplified for
+    /// fixed system paths (`/usr/bin/codesign`, `/usr/bin/security`) that
+    /// need no interactive-shell PATH resolution, and with no timeout: `security
+    /// set-generic-password-partition-list` may need to block on a genuine
+    /// SecurityAgent prompt, so it must not be artificially killed.
+    public static func defaultRun(binary: String, arguments: [String]) async -> ShellResult {
+        await withCheckedContinuation { continuation in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: binary)
+            process.arguments = arguments
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+            process.standardOutput = stdoutPipe
+            process.standardError = stderrPipe
+            process.terminationHandler = { finished in
+                let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(),
+                                    encoding: .utf8) ?? ""
+                let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(),
+                                    encoding: .utf8) ?? ""
+                continuation.resume(returning: ShellResult(stdout: stdout, stderr: stderr,
+                                                            exitCode: finished.terminationStatus))
+            }
+            do {
+                try process.run()
+            } catch {
+                process.terminationHandler = nil
+                continuation.resume(returning: ShellResult(stdout: "", stderr: "process.run() failed: \(error)",
+                                                            exitCode: -1))
+                return
+            }
+        }
+    }
+
+    /// `partition_id` (the `teamid:` ACL entries `set-generic-password-partition-list`
+    /// grants) is a separate authorization gate from the `SecAccess`/
+    /// `SecTrustedApplication` `applications` list `performWrite` already
+    /// sets — command-line-invoked `claude` needs this one too. Looked up
+    /// dynamically via `codesign` rather than hardcoded so a future
+    /// re-signed `claude` binary under a different team doesn't silently
+    /// break this.
+    public static func teamIdentifier(
+        forExecutableAt path: String,
+        run: (String, [String]) async -> ShellResult = defaultRun
+    ) async -> String? {
+        let result = await run("/usr/bin/codesign", ["-dv", "--verbose=4", path])
+        for line in result.stderr.split(separator: "\n", omittingEmptySubsequences: false) {
+            guard line.hasPrefix("TeamIdentifier=") else { continue }
+            let value = line.dropFirst("TeamIdentifier=".count).trimmingCharacters(in: .whitespaces)
+            return value == "not set" ? nil : value
+        }
+        return nil
+    }
+
+    /// Grants `teamID` (plus the `apple-tool:`/`apple:` markers `claude`'s
+    /// own writes use) onto the live item's `partition_id` list — the ACL
+    /// gate `SecAccessCreate` doesn't touch, see `teamIdentifier`'s doc
+    /// comment.
+    public static func setPartitionList(
+        teamID: String,
+        account: String,
+        service: String = service,
+        run: (String, [String]) async -> ShellResult = defaultRun
+    ) async -> Bool {
+        let result = await run("/usr/bin/security", [
+            "set-generic-password-partition-list",
+            "-S", "apple-tool:,apple:,teamid:\(teamID)",
+            "-s", service,
+            "-a", account,
+        ])
+        return result.exitCode == 0
     }
 }

--- a/Sources/StatusBarCore/Accounts/NativeAccountSwitcher.swift
+++ b/Sources/StatusBarCore/Accounts/NativeAccountSwitcher.swift
@@ -26,10 +26,7 @@ public actor NativeAccountSwitcher {
         writeVaultBackup: @escaping (String, CredentialBackup) -> Bool = { AccountCredentialVault.write(accountId: $0, $1) },
         readLiveCredentials: @escaping () -> Data? = { LiveCredentialWriter.read() },
         writeLiveCredentials: @escaping (Data) async -> Bool = { data in
-            let claudePath = await ClaudeBinaryLocator.shared.resolve()
-            return LiveCredentialWriter.write(data, trustedPaths: LiveCredentialWriter.trustedPaths(
-                thisAppPath: Bundle.main.bundlePath,
-                claudePath: claudePath))
+            LiveCredentialWriter.writeValue(data)
         },
         readLiveOauthBlock: @escaping () -> Data? = { NativeAccountSwitcher.defaultReadLiveOauthBlock() },
         writeLiveOauthBlock: @escaping (Data?) -> Bool = { blockData in

--- a/Tests/StatusBarCoreTests/LiveCredentialWriterTests.swift
+++ b/Tests/StatusBarCoreTests/LiveCredentialWriterTests.swift
@@ -32,6 +32,22 @@ import Testing
         #expect(ok == false)
     }
 
+    @Test func writeValuePassesDataAndServiceThrough() {
+        var captured: (Data, String)?
+        let ok = LiveCredentialWriter.writeValue(Data("token".utf8)) { data, service in
+            captured = (data, service)
+            return true
+        }
+        #expect(ok)
+        #expect(captured?.0 == Data("token".utf8))
+        #expect(captured?.1 == LiveCredentialWriter.service)
+    }
+
+    @Test func writeValueFailsWhenWriterFails() {
+        let ok = LiveCredentialWriter.writeValue(Data()) { _, _ in false }
+        #expect(ok == false)
+    }
+
     @Test func trustedPathsDropsNilClaudePath() {
         let paths = LiveCredentialWriter.trustedPaths(thisAppPath: "/Applications/App.app", claudePath: nil)
         #expect(paths == ["/Applications/App.app"])
@@ -151,6 +167,168 @@ import Testing
             add: { _, _ in errSecDuplicateItem }
         )
 
+        #expect(ok == false)
+    }
+
+    // MARK: - performWriteValue
+
+    @Test func performWriteValueUpdatesInPlaceWhenItemExists() {
+        var capturedQuery: [String: Any]?
+        var capturedUpdateAttributes: [String: Any]?
+        var addCalled = false
+
+        let ok = LiveCredentialWriter.performWriteValue(
+            data: Data("token".utf8),
+            service: LiveCredentialWriter.service,
+            account: "ser",
+            update: { query, attributes in
+                capturedQuery = query as? [String: Any]
+                capturedUpdateAttributes = attributes as? [String: Any]
+                return errSecSuccess
+            },
+            add: { _, _ in
+                addCalled = true
+                return errSecSuccess
+            }
+        )
+
+        #expect(ok)
+        #expect(addCalled == false)
+        #expect(capturedQuery?[kSecAttrService as String] as? String == LiveCredentialWriter.service)
+        #expect(capturedQuery?[kSecAttrAccount as String] as? String == "ser")
+        #expect(capturedQuery?[kSecAttrLabel as String] as? String == LiveCredentialWriter.service)
+        #expect(capturedUpdateAttributes?[kSecValueData as String] as? Data == Data("token".utf8))
+        #expect(capturedUpdateAttributes?[kSecAttrAccess as String] == nil)
+    }
+
+    @Test func performWriteValueFallsBackToAddWhenItemMissing() {
+        var capturedAddAttributes: [String: Any]?
+
+        let ok = LiveCredentialWriter.performWriteValue(
+            data: Data("token".utf8),
+            service: LiveCredentialWriter.service,
+            account: "ser",
+            update: { _, _ in errSecItemNotFound },
+            add: { attributes, _ in
+                capturedAddAttributes = attributes as? [String: Any]
+                return errSecSuccess
+            }
+        )
+
+        #expect(ok)
+        #expect(capturedAddAttributes?[kSecAttrService as String] as? String == LiveCredentialWriter.service)
+        #expect(capturedAddAttributes?[kSecAttrAccount as String] as? String == "ser")
+        #expect(capturedAddAttributes?[kSecValueData as String] as? Data == Data("token".utf8))
+        #expect(capturedAddAttributes?[kSecAttrAccess as String] == nil)
+    }
+
+    @Test func performWriteValueFailsWithoutFallingBackOnOtherUpdateErrors() {
+        var addCalled = false
+
+        let ok = LiveCredentialWriter.performWriteValue(
+            data: Data("token".utf8),
+            service: LiveCredentialWriter.service,
+            account: "ser",
+            update: { _, _ in errSecAuthFailed },
+            add: { _, _ in
+                addCalled = true
+                return errSecSuccess
+            }
+        )
+
+        #expect(ok == false)
+        #expect(addCalled == false)
+    }
+
+    @Test func performWriteValueReturnsFalseWhenAddFallbackFails() {
+        let ok = LiveCredentialWriter.performWriteValue(
+            data: Data("token".utf8),
+            service: LiveCredentialWriter.service,
+            account: "ser",
+            update: { _, _ in errSecItemNotFound },
+            add: { _, _ in errSecDuplicateItem }
+        )
+
+        #expect(ok == false)
+    }
+
+    // MARK: - teamIdentifier
+
+    @Test func teamIdentifierParsesTeamIdentifierLineFromStderr() async {
+        let result = await LiveCredentialWriter.teamIdentifier(forExecutableAt: "/opt/homebrew/bin/claude") { _, _ in
+            LiveCredentialWriter.ShellResult(
+                stdout: "",
+                stderr: """
+                Executable=/opt/homebrew/bin/claude
+                Identifier=com.anthropic.claude
+                Format=Mach-O thin (arm64)
+                TeamIdentifier=ABCDE12345
+                Sealed Resources=none
+                """,
+                exitCode: 0
+            )
+        }
+        #expect(result == "ABCDE12345")
+    }
+
+    @Test func teamIdentifierReturnsNilWhenNotSet() async {
+        let result = await LiveCredentialWriter.teamIdentifier(forExecutableAt: "/opt/homebrew/bin/claude") { _, _ in
+            LiveCredentialWriter.ShellResult(stdout: "", stderr: "TeamIdentifier=not set\n", exitCode: 0)
+        }
+        #expect(result == nil)
+    }
+
+    @Test func teamIdentifierReturnsNilWhenNoTeamIdentifierLine() async {
+        let result = await LiveCredentialWriter.teamIdentifier(forExecutableAt: "/opt/homebrew/bin/claude") { _, _ in
+            LiveCredentialWriter.ShellResult(stdout: "", stderr: "Executable=/opt/homebrew/bin/claude\nIdentifier=com.anthropic.claude", exitCode: 0)
+        }
+        #expect(result == nil)
+    }
+
+    @Test func teamIdentifierPassesPathThroughToRun() async {
+        var capturedArguments: [String]?
+        _ = await LiveCredentialWriter.teamIdentifier(forExecutableAt: "/opt/homebrew/bin/claude") { binary, arguments in
+            capturedArguments = arguments
+            #expect(binary == "/usr/bin/codesign")
+            return LiveCredentialWriter.ShellResult(stdout: "", stderr: "", exitCode: 0)
+        }
+        #expect(capturedArguments?.last == "/opt/homebrew/bin/claude")
+    }
+
+    // MARK: - setPartitionList
+
+    @Test func setPartitionListPassesFormattedArgumentsThrough() async {
+        var capturedArguments: [String]?
+        var capturedBinary: String?
+        _ = await LiveCredentialWriter.setPartitionList(
+            teamID: "ABCDE12345",
+            account: "ser",
+            service: LiveCredentialWriter.service
+        ) { binary, arguments in
+            capturedBinary = binary
+            capturedArguments = arguments
+            return LiveCredentialWriter.ShellResult(stdout: "", stderr: "", exitCode: 0)
+        }
+        #expect(capturedBinary == "/usr/bin/security")
+        #expect(capturedArguments == [
+            "set-generic-password-partition-list",
+            "-S", "apple-tool:,apple:,teamid:ABCDE12345",
+            "-s", LiveCredentialWriter.service,
+            "-a", "ser",
+        ])
+    }
+
+    @Test func setPartitionListReturnsTrueOnZeroExitCode() async {
+        let ok = await LiveCredentialWriter.setPartitionList(teamID: "ABCDE12345", account: "ser") { _, _ in
+            LiveCredentialWriter.ShellResult(stdout: "", stderr: "", exitCode: 0)
+        }
+        #expect(ok)
+    }
+
+    @Test func setPartitionListReturnsFalseOnNonzeroExitCode() async {
+        let ok = await LiveCredentialWriter.setPartitionList(teamID: "ABCDE12345", account: "ser") { _, _ in
+            LiveCredentialWriter.ShellResult(stdout: "", stderr: "some error", exitCode: 1)
+        }
         #expect(ok == false)
     }
 }


### PR DESCRIPTION
## Summary
- `NativeAccountSwitcher.writeLiveCredentials` called `LiveCredentialWriter.write` (`performWrite`) on every account switch, which rewrites `kSecAttrAccess` and resets any existing "Always Allow" grant on the shared `Claude Code-credentials` item. Since switches happen far more often than app launches, this was likely the dominant source of the "asked for Keychain permission a lot" reports.
- New `writeValue`/`performWriteValue` path updates only `kSecValueData`/`kSecAttrAccessible`, never `kSecAttrAccess`. Account switching now goes through this path; `LiveCredentialSelfHeal` remains the only thing that ever rewrites the ACL, already gated behind its own non-interactive already-trusted probe.
- Also keeps (still unwired, for manual use) `teamIdentifier`/`setPartitionList`/`defaultRun` helpers for granting the `partition_id` ACL entry command-line `claude` needs, with the team ID resolved dynamically via `codesign` rather than hardcoded.

## Test plan
- [x] `swift build` — clean
- [x] `swift test` — 240/240 passing, including new `LiveCredentialWriterTests` coverage for `writeValue`/`performWriteValue`/`teamIdentifier`/`setPartitionList`
- [ ] CI green
- [ ] Manual: switch accounts a few times, confirm Keychain "Always Allow" isn't re-prompted between switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)