### PR TITLE
Re-assert Keychain trust immediately on wake from sleep

### DIFF
--- a/Sources/ClaudeStatusBar/AppState.swift
+++ b/Sources/ClaudeStatusBar/AppState.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Observation
 import StatusBarCore
@@ -48,6 +49,10 @@ final class AppState {
     /// the first real Keychain read of a launch — see its assignment in
     /// `start()` for why that ordering matters.
     private var selfHealTask: Task<Bool, Never>?
+    /// Kept only so the observer could be removed later; nothing currently
+    /// does, matching the other loop `Task`s in `start()` which also run for
+    /// the app's lifetime with no explicit teardown.
+    private var wakeObserver: NSObjectProtocol?
 
     private let credentialsFile = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent(".claude/.credentials.json")
@@ -88,6 +93,22 @@ final class AppState {
         // fixing trust before that interactive-capable read can fire.
         selfHealTask = Task {
             await LiveCredentialSelfHeal.run(diagnosticLog: paths.root.appendingPathComponent("native-switch.log"))
+        }
+        // claude's own token refresh can reset the ACL mid-session (see
+        // usageInputs(_:)'s doc comment) — after a long sleep, the token is
+        // likelier to be due for refresh right as the user resumes work, and
+        // self-heal's other triggers (this launch-time run, and the one
+        // usageInputs(_:) re-runs on every call) only fire on the next poll
+        // cycle or account switch. That leaves a window, right when the user
+        // is most likely to invoke claude, where the ACL is untrusted and
+        // Keychain prompts. Waking is a sharp, cheap signal to close it early.
+        wakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task {
+                await LiveCredentialSelfHeal.run(diagnosticLog: self.paths.root.appendingPathComponent("native-switch.log"))
+            }
         }
         reaggregate()
 


### PR DESCRIPTION
## Summary
- Repeated Keychain "Always Allow" prompts were reported specifically after waking the Mac from sleep, not after an actual reboot (`uptime`/`kern.boottime` confirm no reboot in 58 days).
- `claude`'s own token-refresh flow resets the shared `"Claude Code-credentials"` item's ACL mid-session (see `usageInputs(_:)`'s doc comment). The existing self-heal mitigation only re-runs on the next poll cycle (default every 5 min) or account switch — leaving a window right after wake, exactly when the user is most likely to invoke `claude` again, where the ACL is still untrusted.
- Adds an `NSWorkspace.didWakeNotification` observer in `AppState.start()` that immediately triggers `LiveCredentialSelfHeal.run`, closing that window instead of waiting for the next poll.
- This is unrelated to #38 (which fixes ACL resets triggered by account switching) — this fixes the wake-triggered case.

## Test plan
- [x] `swift build` — clean
- [x] `swift test` — 240/240 passing
- [ ] Owner review + CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)