### PR TITLE
Bump version to 0.1.10

### DIFF
--- a/Sources/StatusBarCore/StatusBarCore.swift
+++ b/Sources/StatusBarCore/StatusBarCore.swift
@@ -1,3 +1,3 @@
 public enum StatusBarCoreInfo {
-    public static let version = "0.1.9"
+    public static let version = "0.1.10"
 }

--- a/Tests/StatusBarCoreTests/PackageTests.swift
+++ b/Tests/StatusBarCoreTests/PackageTests.swift
@@ -2,5 +2,5 @@ import Testing
 @testable import StatusBarCore
 
 @Test func versionIsSet() {
-    #expect(StatusBarCoreInfo.version == "0.1.9")
+    #expect(StatusBarCoreInfo.version == "0.1.10")
 }

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-VERSION="${VERSION:-0.1.9}"
+VERSION="${VERSION:-0.1.10}"
 APP="dist/ClaudeStatusBar.app"
 BIN=".build/release"
 


### PR DESCRIPTION
## Summary
- Bumps version to 0.1.10 ahead of tagging, bundling #38 (account-switch ACL fix) and #39 (wake-from-sleep self-heal trigger).

## Test plan
- [x] `swift test` — 240/240 passing
- [ ] Owner review + CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)