### PR TITLE
Make periodic Keychain-fallback read non-interactive

### DIFF
--- a/Sources/StatusBarCore/Accounts/AccountDiscovery.swift
+++ b/Sources/StatusBarCore/Accounts/AccountDiscovery.swift
@@ -87,14 +87,33 @@ public enum AccountDiscovery {
     }
 
     public static func defaultKeychainReader(service: String) -> Data? {
+        performKeychainRead(service: service)
+    }
+
+    /// Uses `kSecUseAuthenticationUIFail` so this read can never pop an
+    /// interactive Keychain prompt — unlike `LiveCredentialWriter.read`
+    /// (self-heal's own repair path, which legitimately needs to prompt to
+    /// (re-)establish trust), this read backs the periodic usage-fetch path
+    /// and runs on every poll cycle from several independent, uncoordinated
+    /// timer loops in `AppState` (`pollTask`, `captureTask`,
+    /// `wakeObserver`). Without this, a burst of those loops firing at once
+    /// right after wake — each still needing to establish trust — could each
+    /// independently trigger their own "ClaudeStatusBar wants to access..."
+    /// dialog. `copyMatching` is injectable so tests can capture the query
+    /// without touching the real Keychain.
+    static func performKeychainRead(
+        service: String,
+        copyMatching: (CFDictionary, UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus = SecItemCopyMatching
+    ) -> Data? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrLabel as String: service,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecUseAuthenticationUI as String: kSecUseAuthenticationUIFail,
         ]
         var item: CFTypeRef?
-        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+        guard copyMatching(query as CFDictionary, &item) == errSecSuccess,
               let data = item as? Data else { return nil }
         return data
     }

--- a/Sources/StatusBarCore/Accounts/TokenResolution.swift
+++ b/Sources/StatusBarCore/Accounts/TokenResolution.swift
@@ -2,9 +2,11 @@ import Foundation
 
 /// Which branch of the token-resolution decision produced a token — tracked
 /// so a poll cycle can log which one fired instead of just the resulting
-/// token. The Keychain-fallback branch firing unexpectedly for an account
-/// that should already have a token on disk is the leading hypothesis for
-/// the still-unexplained intermittent Keychain re-prompt.
+/// token. The Keychain-fallback branch used to be able to trigger an
+/// interactive Keychain prompt from several independent poll loops at once
+/// right after wake (see `AccountDiscovery.performKeychainRead`'s doc
+/// comment) — fixed by making that read non-interactive, but the source
+/// tracking here stays useful for spotting future regressions.
 public enum TokenSource: String, Sendable {
     case oauthFile
     case keychainFallback
@@ -52,13 +54,12 @@ public enum TokenResolution {
     }
 }
 
-/// One poll cycle's token-resolution decisions, written to give the
-/// still-unexplained intermittent Keychain re-prompt real evidence: if
-/// `tokenSource=keychainFallback` shows up here right when the prompt fires,
+/// One poll cycle's token-resolution decisions, written so future Keychain
+/// prompt reports have real evidence to check instead of a guess: if
+/// `tokenSource=keychainFallback` shows up here right when a prompt fires,
 /// and `orgUuid` is unexpectedly nil for an account that should already have
-/// one, that's a real clue instead of a guess. Never includes a token
-/// value, per this app's rule that tokens are read at request time only and
-/// never logged.
+/// one, that's a real clue. Never includes a token value, per this app's
+/// rule that tokens are read at request time only and never logged.
 public enum TokenResolutionDiagnostics {
     public struct Entry: Sendable {
         public let accountId: String

--- a/Tests/StatusBarCoreTests/AccountDiscoveryTests.swift
+++ b/Tests/StatusBarCoreTests/AccountDiscoveryTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 import Testing
 @testable import StatusBarCore
 
@@ -97,6 +98,33 @@ private func makeTempDir() -> URL {
         let token = AccountDiscovery.keychainAccessToken(
             service: "Claude Code-credentials", reader: { _ in Data("nope".utf8) })
         #expect(token == nil)
+    }
+}
+
+/// defaultKeychainReader must never be able to pop an interactive Keychain
+/// prompt: unlike LiveCredentialWriter.read (self-heal's own repair path,
+/// which legitimately needs to prompt to (re-)establish trust), this read
+/// backs the periodic usage-fetch path and runs on every poll cycle from
+/// several independent, uncoordinated timer loops in AppState. Without
+/// kSecUseAuthenticationUIFail, a burst of those loops firing at once right
+/// after wake can each independently trigger their own "ClaudeStatusBar
+/// wants to access..." dialog.
+@Suite struct DefaultKeychainReaderQueryTests {
+    @Test func setsAuthenticationUIFailToAvoidInteractivePrompts() {
+        var capturedQuery: [String: Any]?
+        _ = AccountDiscovery.performKeychainRead(service: "Claude Code-credentials") { query, _ in
+            capturedQuery = query as? [String: Any]
+            return errSecItemNotFound
+        }
+        let authUI = capturedQuery?[kSecUseAuthenticationUI as String] as? String
+        #expect(authUI == (kSecUseAuthenticationUIFail as String))
+    }
+
+    @Test func returnsNilWhenCopyMatchingFails() {
+        let result = AccountDiscovery.performKeychainRead(service: "Claude Code-credentials") { _, _ in
+            errSecItemNotFound
+        }
+        #expect(result == nil)
     }
 }
 


### PR DESCRIPTION
## Summary
- Root cause of the "asked 3 times right after reopening the machine" report on v0.1.10: `AccountDiscovery.defaultKeychainReader` (reached via `TokenResolution`'s `keychainFallback` branch on every poll cycle) had no `kSecUseAuthenticationUIFail`, unlike `LiveCredentialWriter`'s trust probe.
- Right after true wake, several independent `AppState` timer loops (`pollTask`, `captureTask`, `wakeObserver`) can have their `Task.sleep` deadlines elapse in a near-simultaneous burst — `native-switch.log` shows 4 self-heal entries within 21 seconds versus the normal ~60s cadence. Each loop's `usageInputs(_:)` call reaches the un-guarded read independently, and without the auth-UI-fail flag each one still missing trust could pop its own interactive prompt.
- Fix scopes narrowly to `AccountDiscovery.defaultKeychainReader`: adds `kSecUseAuthenticationUIFail` so a poll cycle simply fails to get a token that cycle (retried next cycle) instead of ever showing a dialog. `LiveCredentialWriter.read` (self-heal's own repair path) is deliberately left interactive-capable — that's the actual mechanism that (re-)establishes ACL trust.

## Test plan
- [x] `swift test` — full `StatusBarCoreTests` suite (242 tests) passes
- [x] New `DefaultKeychainReaderQueryTests` suite added: asserts the query sets `kSecUseAuthenticationUIFail`, and that a failed `copyMatching` returns nil cleanly
- [x] `swift build` succeeds (pre-existing deprecation warnings only, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)