### PR TITLE
Bump version to 0.1.11

### DIFF
--- a/Sources/StatusBarCore/StatusBarCore.swift
+++ b/Sources/StatusBarCore/StatusBarCore.swift
@@ -1,3 +1,3 @@
 public enum StatusBarCoreInfo {
-    public static let version = "0.1.10"
+    public static let version = "0.1.11"
 }

--- a/Tests/StatusBarCoreTests/PackageTests.swift
+++ b/Tests/StatusBarCoreTests/PackageTests.swift
@@ -2,5 +2,5 @@ import Testing
 @testable import StatusBarCore
 
 @Test func versionIsSet() {
-    #expect(StatusBarCoreInfo.version == "0.1.10")
+    #expect(StatusBarCoreInfo.version == "0.1.11")
 }

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-VERSION="${VERSION:-0.1.10}"
+VERSION="${VERSION:-0.1.11}"
 APP="dist/ClaudeStatusBar.app"
 BIN=".build/release"
 


### PR DESCRIPTION
## Summary
- Version bump for the next release, following the Keychain-fallback non-interactive-read fix in #41.

## Test plan
- [x] `swift test --filter versionIsSet` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)