### PR TITLE
Refresh usage on popover open and wake, throttled to 30s

### DIFF
--- a/Sources/ClaudeStatusBar/AppState.swift
+++ b/Sources/ClaudeStatusBar/AppState.swift
@@ -107,7 +107,11 @@ final class AppState {
         ) { [weak self] _ in
             guard let self else { return }
             Task {
-                await LiveCredentialSelfHeal.run(diagnosticLog: self.paths.root.appendingPathComponent("native-switch.log"))
+                _ = await LiveCredentialSelfHeal.run(diagnosticLog: self.paths.root.appendingPathComponent("native-switch.log"))
+                // Waking is also a sharp signal that usage data may be
+                // stale (the poll loop paused for the whole sleep). Throttled
+                // like the popover-open trigger — see refreshUsageIfNeeded().
+                await self.refreshUsageIfNeeded()
             }
         }
         reaggregate()
@@ -225,6 +229,19 @@ final class AppState {
     func refreshUsageNow() async {
         accounts = resolveAccounts()
         await usageStore.refresh(accounts: await usageInputs(accounts))
+    }
+
+    /// Popover-open and wake-from-sleep both call this instead of
+    /// `refreshUsageNow()` directly: it skips the refresh when
+    /// `UsageStore.shouldRefresh` says the last successful fetch is still
+    /// recent, so neither trigger can hammer the API by firing repeatedly
+    /// (popover reopened, laptop waking in quick succession). The throttle
+    /// window itself is decided in StatusBarCore (testable); a throttled-in
+    /// call still goes through the normal `refreshUsageNow()` path, so the
+    /// existing per-account failure backoff still applies.
+    func refreshUsageIfNeeded() async {
+        guard usageStore.shouldRefresh() else { return }
+        await refreshUsageNow()
     }
 
     private func resolveAccounts() -> [Account] {

--- a/Sources/ClaudeStatusBar/AppState.swift
+++ b/Sources/ClaudeStatusBar/AppState.swift
@@ -45,6 +45,14 @@ final class AppState {
     private var tickInterval: Duration = .seconds(1)
     private var pollCycle = 0
     private var started = false
+    /// Guards `refreshUsageIfNeeded()` against the popover-open and
+    /// wake-from-sleep triggers firing near-simultaneously: both check
+    /// `usageStore.shouldRefresh()` before either's `refreshUsageNow()` call
+    /// has completed, so `lastSuccessfulRefreshAt` alone can't stop a second
+    /// concurrent refresh. Race-free because the check-and-set in
+    /// `refreshUsageIfNeeded()` has no `await` between them — the whole
+    /// guard runs as one uninterrupted step on this actor.
+    private var refreshInFlight = false
     /// Stored (not fire-and-forget) so `usageInputs(_:)` can await it before
     /// the first real Keychain read of a launch — see its assignment in
     /// `start()` for why that ordering matters.
@@ -239,8 +247,17 @@ final class AppState {
     /// window itself is decided in StatusBarCore (testable); a throttled-in
     /// call still goes through the normal `refreshUsageNow()` path, so the
     /// existing per-account failure backoff still applies.
+    ///
+    /// `refreshInFlight` additionally covers the case the timestamp-based
+    /// throttle alone can't: wake and popover-open firing close enough
+    /// together that neither's `refreshUsageNow()` has finished (and so
+    /// written `lastSuccessfulRefreshAt`) by the time the other's check
+    /// runs. Without it both would pass `shouldRefresh()` and fire a
+    /// duplicate concurrent fetch.
     func refreshUsageIfNeeded() async {
-        guard usageStore.shouldRefresh() else { return }
+        guard !refreshInFlight, usageStore.shouldRefresh() else { return }
+        refreshInFlight = true
+        defer { refreshInFlight = false }
         await refreshUsageNow()
     }
 

--- a/Sources/ClaudeStatusBar/PopoverView.swift
+++ b/Sources/ClaudeStatusBar/PopoverView.swift
@@ -54,5 +54,9 @@ struct PopoverView: View {
         // after the user logs back in, instead of waiting out the poll
         // loop's failure backoff.
         .task { await appState.recheckReloginAccounts() }
+        // Also runs on every popover open, throttled (see
+        // refreshUsageIfNeeded()) so a quickly reopened popover shows
+        // current usage instead of waiting out the poll interval.
+        .task { await appState.refreshUsageIfNeeded() }
     }
 }

--- a/Sources/StatusBarCore/Usage/UsageStore.swift
+++ b/Sources/StatusBarCore/Usage/UsageStore.swift
@@ -24,6 +24,12 @@ public final class UsageStore {
     let fetcher: UsageFetching
     let cacheFile: URL
     public private(set) var states: [String: AccountUsageState] = [:]
+    /// Set only when `refresh(accounts:)` fetches at least one account
+    /// successfully — a call that only produced failures leaves this
+    /// untouched, so `shouldRefresh` never treats a failed attempt as a
+    /// reason to withhold a retry. Backs the popover-open / wake-from-sleep
+    /// throttle in `AppState` (see `shouldRefresh(now:minGap:)`).
+    public private(set) var lastSuccessfulRefreshAt: Date?
 
     public init(fetcher: UsageFetching, cacheFile: URL) {
         self.fetcher = fetcher
@@ -40,7 +46,7 @@ public final class UsageStore {
         return cycle % interval != 0
     }
 
-    public func refresh(accounts: [(account: Account, token: String?)]) async {
+    public func refresh(accounts: [(account: Account, token: String?)], now: Date = Date()) async {
         let fetcher = self.fetcher
         let fetched = await withTaskGroup(
             of: (String, Result<UsageSnapshot, UsageError>).self
@@ -64,12 +70,14 @@ public final class UsageStore {
             return collected
         }
 
+        var hadSuccess = false
         for (account, token) in accounts {
             let id = account.id
             var state = states[id] ?? AccountUsageState()
             switch token.flatMap({ _ in fetched[id] }) {
             case .success(let snapshot):
                 state = AccountUsageState(snapshot: snapshot, freshness: .fresh)
+                hadSuccess = true
             case .failure(.unauthorized):
                 state.freshness = .stale
                 state.needsRelogin = true
@@ -91,7 +99,19 @@ public final class UsageStore {
             }
             states[id] = state
         }
+        if hadSuccess { lastSuccessfulRefreshAt = now }
         saveCache()
+    }
+
+    /// Whether a caller (popover-open, wake-from-sleep) should trigger
+    /// `refresh(accounts:)` right now, or skip because usage data is still
+    /// recent enough — throttles those two triggers to at most once every
+    /// `minGap` seconds so repeatedly opening the popover doesn't hammer the
+    /// API. A failed refresh doesn't set `lastSuccessfulRefreshAt`, so it
+    /// never blocks a retry.
+    public func shouldRefresh(now: Date = Date(), minGap: TimeInterval = 30) -> Bool {
+        guard let last = lastSuccessfulRefreshAt else { return true }
+        return now.timeIntervalSince(last) >= minGap
     }
 
     /// Marks the given account ids as needing relogin, without disturbing

--- a/Tests/StatusBarCoreTests/UsageStoreTests.swift
+++ b/Tests/StatusBarCoreTests/UsageStoreTests.swift
@@ -175,4 +175,41 @@ private func makeStore(_ results: [String: Result<UsageSnapshot, UsageError>]) -
         store.seedNeedsRelogin(["native-0"])
         #expect(store.states["native-0"]?.needsRelogin == true)
     }
+
+    // MARK: - shouldRefresh (popover-open / wake throttle)
+
+    @Test func shouldRefreshAllowedWhenNeverRefreshed() {
+        let store = UsageStore(fetcher: FailingFetcher(), cacheFile: tempCacheFile())
+        #expect(store.shouldRefresh(now: Date(), minGap: 30))
+    }
+
+    @Test func shouldRefreshAllowedAtOrAfterMinGap() async {
+        let (store, cache) = makeStore(["tok": .success(snap(10))])
+        defer { try? FileManager.default.removeItem(at: cache.deletingLastPathComponent()) }
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        await store.refresh(accounts: [(account("a"), "tok")], now: t0)
+
+        #expect(store.shouldRefresh(now: t0.addingTimeInterval(30), minGap: 30))
+        #expect(store.shouldRefresh(now: t0.addingTimeInterval(45), minGap: 30))
+    }
+
+    @Test func shouldRefreshSkippedBeforeMinGap() async {
+        let (store, cache) = makeStore(["tok": .success(snap(10))])
+        defer { try? FileManager.default.removeItem(at: cache.deletingLastPathComponent()) }
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        await store.refresh(accounts: [(account("a"), "tok")], now: t0)
+
+        #expect(!store.shouldRefresh(now: t0.addingTimeInterval(29), minGap: 30))
+    }
+
+    @Test func failedRefreshDoesNotCountAsRecentSuccessForThrottle() async {
+        let (store, cache) = makeStore(["tok": .failure(.network)])
+        defer { try? FileManager.default.removeItem(at: cache.deletingLastPathComponent()) }
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        await store.refresh(accounts: [(account("a"), "tok")], now: t0)
+
+        // A failed refresh must not start the throttle window — refreshing
+        // again a second later is still allowed.
+        #expect(store.shouldRefresh(now: t0.addingTimeInterval(1), minGap: 30))
+    }
 }


### PR DESCRIPTION
## Summary
- Usage data could be up to a full poll interval (default 5 min) stale even right when the user opened the popover or the Mac woke from sleep, since neither trigger touched `UsageStore` before this change.
- Adds `UsageStore.lastSuccessfulRefreshAt` + `shouldRefresh(now:minGap:)` (StatusBarCore, testable): true when never refreshed or the last *successful* refresh is >=30s old; a failed refresh never sets the timestamp, so it can't block a retry.
- `UsageStore.refresh(accounts:now:)` gained an injectable `now` parameter (default `Date()`) so the timestamp -- and the tests -- don't depend on wall-clock sleeps.
- `AppState.refreshUsageIfNeeded()` wraps `refreshUsageNow()` with that throttle check; called from `PopoverView`'s `.task` on every popover open, and from the `NSWorkspace.didWakeNotification` observer right after the existing credential self-heal.
- Throttled-in calls still go through the normal `refreshUsageNow()` -> `UsageStore.refresh()` path, so the existing per-account failure backoff (`shouldSkip`) is untouched.
- Out of scope, untouched: the 1/5/15 poll interval picker, `StatusBarCoreInfo.version`, `scripts/make-app.sh`.
- **Follow-up from review:** `lastSuccessfulRefreshAt` alone doesn't stop wake and popover-open firing close enough together that neither `refreshUsageNow()` call has finished (and written the timestamp) by the time the other's throttle check runs -- both would then pass and fire a duplicate concurrent fetch. Added a `refreshInFlight` guard on `AppState` (MainActor, set synchronously before the first `await`) to close that window. `UsageStore` and `refreshUsageNow()` are unchanged.

## Files changed
- `Sources/StatusBarCore/Usage/UsageStore.swift` -- `lastSuccessfulRefreshAt`, `shouldRefresh(now:minGap:)`, `refresh(accounts:now:)`.
- `Sources/ClaudeStatusBar/AppState.swift` -- `refreshUsageIfNeeded()` with a `refreshInFlight` guard against concurrent wake+popover triggers; wake observer now also calls it after self-heal.
- `Sources/ClaudeStatusBar/PopoverView.swift` -- added `.task { await appState.refreshUsageIfNeeded() }`.
- `Tests/StatusBarCoreTests/UsageStoreTests.swift` -- 4 new tests: never-refreshed allowed, >=30s allowed, <30s skipped, failed refresh doesn't count as recent success.

## Test plan
- [x] TDD: added failing tests first (compile failure on missing `UsageStore.shouldRefresh`/`now:` param), then implemented minimally.
- [x] `swift test` -- full suite: 246/246 passed (16 in `UsageStoreTests`, including the 4 new throttle tests).
- [x] `swift build` -- clean, no warnings.
- [x] Fresh-context review (no CRITICAL findings); one MINOR (cross-trigger race) fixed with the `refreshInFlight` guard above. `AppState` has no unit test suite in this repo, so the guard itself is unit-test-free by convention -- covered by the build/test run staying green.
- [ ] Manual: open/close the popover rapidly and confirm no extra network calls within 30s; sleep/wake the Mac and confirm a usage refresh fires once, throttled if a popover refresh already happened recently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

