### PR TITLE
Fix stale native-accounts.json pointer corrupting vault backups on switch

### DIFF
--- a/Sources/StatusBarCore/Accounts/NativeAccountSwitcher.swift
+++ b/Sources/StatusBarCore/Accounts/NativeAccountSwitcher.swift
@@ -73,7 +73,44 @@ public actor NativeAccountSwitcher {
 
     public func switchTo(account: Account) async -> Bool {
         let state = loadState(stateFile)
-        guard state.activeId != account.id else { return true }
+
+        // `state.activeId` is only ever this app's own memory of who's
+        // live — it goes stale the moment anything switches live
+        // credentials without going through this method: the token-slayer
+        // backend (AppState.switchAccount's slayer branch never calls
+        // switchTo), or a bare `token-slayer switch <name>` run directly in
+        // a terminal. Reading the *live* oauthAccount block and matching it
+        // against the accounts this app tracks derives who's really live,
+        // independent of that pointer. Read once up front — before the
+        // early-return guard below — and reuse the same snapshot later as
+        // this switch's outgoing oauth block, so both the guard and the
+        // vault backup destination are decided from the same live read.
+        let currentLiveOauthBlock = readLiveOauthBlock()
+        let liveOwner = Self.resolveLiveOwner(liveOauthBlock: currentLiveOauthBlock, accounts: state.accounts)
+
+        let effectiveOutgoingId: String?
+        switch liveOwner {
+        case .notApplicable:
+            // No identifying data could be extracted from the live block at
+            // all (unreadable, or present but missing both organizationUuid
+            // and emailAddress) — nothing to contradict the stored pointer
+            // with, so fall back to trusting it exactly as before.
+            effectiveOutgoingId = state.activeId
+        case .identified(let ownerId):
+            // Live state positively identifies who's really active —
+            // trust that over the stored pointer even when they agree,
+            // since agreement here is confirmed rather than assumed.
+            effectiveOutgoingId = ownerId
+        case .unidentifiable:
+            // The live block positively matches zero tracked accounts, or
+            // matches more than one (ambiguous). Guessing which vault entry
+            // to overwrite from here risks destroying an unrelated
+            // account's stored refresh token, so refuse instead.
+            writeDiagnostic("switch to \(account.id) failed: could not verify which tracked account currently owns the live credentials (no match, or an ambiguous match, against native-accounts.json) — refusing to guess and risk corrupting a vault backup")
+            return false
+        }
+
+        guard effectiveOutgoingId != account.id else { return true }
 
         // Re-establish trust for the target account's vault item before
         // reading it: readVaultBackup is now non-interactive (Finding #2),
@@ -99,9 +136,8 @@ public actor NativeAccountSwitcher {
             writeDiagnostic("switch to \(account.id) failed: could not read current live credentials")
             return false
         }
-        let currentLiveOauthBlock = readLiveOauthBlock()
 
-        if let outgoingId = state.activeId {
+        if let outgoingId = effectiveOutgoingId {
             let outgoingBackup = CredentialBackup(liveCredentials: currentLiveCredentials,
                                                   oauthAccountBlock: currentLiveOauthBlock)
             guard writeVaultBackup(outgoingId, outgoingBackup) else {
@@ -172,5 +208,49 @@ public actor NativeAccountSwitcher {
         config["oauthAccount"] = blockObj
         guard let newData = try? JSONSerialization.data(withJSONObject: config) else { return false }
         return (try? AtomicFile.write(newData, to: configFile)) != nil
+    }
+
+    /// Result of matching a live oauthAccount block against the accounts
+    /// `switchTo` tracks in `native-accounts.json`.
+    enum LiveOwnerResolution: Equatable {
+        /// No identifying key (organizationUuid or emailAddress) could be
+        /// extracted from the live block — it was unreadable, or present
+        /// but carries neither field. Not enough to contradict the stored
+        /// pointer, so callers should fall back to trusting it.
+        case notApplicable
+        /// Exactly one tracked account matches the live block's identity.
+        case identified(String)
+        /// The live block carries an identity that matches zero tracked
+        /// accounts, or matches more than one (ambiguous) — a caller must
+        /// not guess from here.
+        case unidentifiable
+    }
+
+    /// Matches organizationUuid first (the more stable identifier — same
+    /// priority `AccountCapture.matchingIndex` uses when reconciling a
+    /// freshly captured login), falling back to email only when no
+    /// organizationUuid was extracted or it matched nothing. A key that
+    /// resolves to more than one tracked account is treated as ambiguous
+    /// rather than picking the first match, since guessing wrong here is
+    /// exactly the corruption this method exists to prevent.
+    static func resolveLiveOwner(liveOauthBlock: Data?, accounts: [NativeAccount]) -> LiveOwnerResolution {
+        guard let liveOauthBlock else { return .notApplicable }
+        let organizationUuid = AccountDiscovery.organizationUuid(from: liveOauthBlock)
+        let email = AccountDiscovery.emailAddress(from: liveOauthBlock)
+        guard organizationUuid != nil || email != nil else { return .notApplicable }
+
+        if let organizationUuid {
+            let matches = accounts.filter { $0.organizationUuid == organizationUuid }
+            if matches.count == 1 { return .identified(matches[0].id) }
+            if matches.count > 1 { return .unidentifiable }
+            // No organizationUuid match: fall through to the email key below.
+        }
+        if let email {
+            let matches = accounts.filter { $0.email == email }
+            if matches.count == 1 { return .identified(matches[0].id) }
+            if matches.count > 1 { return .unidentifiable }
+        }
+        // Had at least one identifying key, but it matched no tracked account.
+        return .unidentifiable
     }
 }

--- a/Tests/StatusBarCoreTests/NativeAccountSwitcherTests.swift
+++ b/Tests/StatusBarCoreTests/NativeAccountSwitcherTests.swift
@@ -312,4 +312,229 @@ import Testing
         let result = await switcher.switchTo(account: account("native-1", state: state))
         #expect(result == false)
     }
+
+    // MARK: - Deriving the true live owner from live state
+
+    /// Builds a fake ~/.claude.json "oauthAccount" block Data, matching the
+    /// shape `AccountDiscovery.organizationUuid(from:)` /
+    /// `.emailAddress(from:)` parse.
+    private func oauthBlock(organizationUuid: String? = nil, email: String? = nil) -> Data {
+        var obj: [String: Any] = [:]
+        if let organizationUuid { obj["organizationUuid"] = organizationUuid }
+        if let email { obj["emailAddress"] = email }
+        return try! JSONSerialization.data(withJSONObject: obj)
+    }
+
+    /// Reproduces the token-slayer divergence bug's failure mode #1: stored
+    /// `activeId` says "native-0" is active, but the live oauthAccount block
+    /// actually identifies "native-1" (org-b) as the true owner — e.g.
+    /// because token-slayer switched live credentials without ever touching
+    /// native-accounts.json. Switching to "native-0" (what the stale pointer
+    /// already claims is active) must NOT silently no-op: the live
+    /// credentials really belong to native-1, so this has to be a real
+    /// switch.
+    @Test func staleStoredActiveIdDoesNotMaskARealSwitch() async {
+        let state = makeState()
+        var vault: [String: CredentialBackup] = [
+            "native-0": CredentialBackup(liveCredentials: Data("native-0-creds".utf8), oauthAccountBlock: nil),
+        ]
+        var liveCredentials = Data("actually-native-1s-creds".utf8)
+        var writeLiveCalled = false
+
+        let switcher = NativeAccountSwitcher(
+            stateFile: URL(fileURLWithPath: "/dev/null"),
+            diagnosticLog: nil,
+            readVaultBackup: { vault[$0] },
+            writeVaultBackup: { id, backup in vault[id] = backup; return true },
+            readLiveCredentials: { liveCredentials },
+            writeLiveCredentials: { data in writeLiveCalled = true; liveCredentials = data; return true },
+            readLiveOauthBlock: { self.oauthBlock(organizationUuid: "org-b", email: "b@example.com") },
+            writeLiveOauthBlock: { _ in true },
+            loadState: { _ in state },
+            saveState: { _, _ in true }
+        )
+
+        let result = await switcher.switchTo(account: account("native-0", state: state))
+
+        #expect(result)
+        #expect(writeLiveCalled)
+        #expect(liveCredentials == Data("native-0-creds".utf8))
+    }
+
+    /// Failure mode #2, the data-loss one: with the same stale-pointer setup
+    /// as above, the live credentials being displaced must be backed up
+    /// under their *true* owner (native-1, derived from the live
+    /// oauthAccount block) — not under the stale stored activeId
+    /// (native-0), which would silently overwrite native-0's own vault entry
+    /// with native-1's credentials.
+    @Test func outgoingBackupGoesToDerivedOwnerNotStaleStoredActiveId() async {
+        let state = makeState()
+        var vault: [String: CredentialBackup] = [
+            "native-0": CredentialBackup(liveCredentials: Data("native-0-original".utf8), oauthAccountBlock: nil),
+        ]
+        let liveCredentials = Data("actually-native-1s-creds".utf8)
+
+        let switcher = NativeAccountSwitcher(
+            stateFile: URL(fileURLWithPath: "/dev/null"),
+            diagnosticLog: nil,
+            readVaultBackup: { _ in CredentialBackup(liveCredentials: Data("native-0-target".utf8), oauthAccountBlock: nil) },
+            writeVaultBackup: { id, backup in vault[id] = backup; return true },
+            readLiveCredentials: { liveCredentials },
+            writeLiveCredentials: { _ in true },
+            readLiveOauthBlock: { self.oauthBlock(organizationUuid: "org-b", email: "b@example.com") },
+            writeLiveOauthBlock: { _ in true },
+            loadState: { _ in state },
+            saveState: { _, _ in true }
+        )
+
+        let result = await switcher.switchTo(account: account("native-0", state: state))
+
+        #expect(result)
+        // native-1 (the real owner of the displaced live credentials) gets
+        // the backup...
+        #expect(vault["native-1"]?.liveCredentials == liveCredentials)
+        // ...and native-0's own vault entry (its true stored backup) must be
+        // left completely untouched.
+        #expect(vault["native-0"]?.liveCredentials == Data("native-0-original".utf8))
+    }
+
+    /// When the live oauthAccount block positively identifies an owner that
+    /// happens to already match the stored activeId, behaviour is exactly
+    /// the pre-existing happy path: the guard fires against the (now
+    /// confirmed, not just assumed) stored id.
+    @Test func identifiedLiveOwnerMatchingStoredActiveIdBehavesLikeUnchangedHappyPath() async {
+        let state = makeState()
+        var vault: [String: CredentialBackup] = [:]
+
+        let switcher = NativeAccountSwitcher(
+            stateFile: URL(fileURLWithPath: "/dev/null"),
+            diagnosticLog: nil,
+            readVaultBackup: { _ in CredentialBackup(liveCredentials: Data("target".utf8), oauthAccountBlock: nil) },
+            writeVaultBackup: { id, backup in vault[id] = backup; return true },
+            readLiveCredentials: { Data("current".utf8) },
+            writeLiveCredentials: { _ in true },
+            readLiveOauthBlock: { self.oauthBlock(organizationUuid: "org-a", email: "a@example.com") },
+            writeLiveOauthBlock: { _ in true },
+            loadState: { _ in state },
+            saveState: { _, _ in true }
+        )
+
+        let result = await switcher.switchTo(account: account("native-1", state: state))
+
+        #expect(result)
+        #expect(vault["native-0"]?.liveCredentials == Data("current".utf8))
+    }
+
+    /// A live oauthAccount block can also identify the owner by email alone
+    /// (no organizationUuid field) — the same fallback order
+    /// `AccountCapture.matchingIndex` already uses.
+    @Test func identifiesLiveOwnerByEmailWhenOrganizationUuidAbsent() async {
+        let state = makeState()
+        var vault: [String: CredentialBackup] = [:]
+
+        let switcher = NativeAccountSwitcher(
+            stateFile: URL(fileURLWithPath: "/dev/null"),
+            diagnosticLog: nil,
+            readVaultBackup: { _ in CredentialBackup(liveCredentials: Data("native-0-target".utf8), oauthAccountBlock: nil) },
+            writeVaultBackup: { id, backup in vault[id] = backup; return true },
+            readLiveCredentials: { Data("actually-native-1s-creds".utf8) },
+            writeLiveCredentials: { _ in true },
+            readLiveOauthBlock: { self.oauthBlock(email: "b@example.com") },
+            writeLiveOauthBlock: { _ in true },
+            loadState: { _ in state },
+            saveState: { _, _ in true }
+        )
+
+        let result = await switcher.switchTo(account: account("native-0", state: state))
+
+        #expect(result)
+        #expect(vault["native-1"]?.liveCredentials == Data("actually-native-1s-creds".utf8))
+    }
+
+    /// The live oauthAccount block positively identifies an org uuid/email
+    /// that matches no tracked account at all — e.g. the live login belongs
+    /// to some account this app never captured. Guessing which vault entry
+    /// to overwrite here would risk destroying an unrelated account's
+    /// backup, so this must abort outright rather than fall back to the
+    /// stale stored activeId.
+    @Test func unidentifiableLiveOwnerAbortsWithoutWritingAnyVaultBackup() async {
+        let state = makeState()
+        var writeVaultBackupCalled = false
+        var writeLiveCalled = false
+
+        let switcher = NativeAccountSwitcher(
+            stateFile: URL(fileURLWithPath: "/dev/null"),
+            diagnosticLog: nil,
+            readVaultBackup: { _ in CredentialBackup(liveCredentials: Data("target".utf8), oauthAccountBlock: nil) },
+            writeVaultBackup: { _, _ in writeVaultBackupCalled = true; return true },
+            readLiveCredentials: { Data("current".utf8) },
+            writeLiveCredentials: { _ in writeLiveCalled = true; return true },
+            readLiveOauthBlock: { self.oauthBlock(organizationUuid: "org-unknown", email: "unknown@example.com") },
+            writeLiveOauthBlock: { _ in true },
+            loadState: { _ in state },
+            saveState: { _, _ in true }
+        )
+
+        let result = await switcher.switchTo(account: account("native-1", state: state))
+
+        #expect(result == false)
+        #expect(writeVaultBackupCalled == false)
+        #expect(writeLiveCalled == false)
+    }
+
+    /// Two tracked accounts sharing the same organizationUuid (a corrupted
+    /// native-accounts.json) makes the live owner ambiguous even though the
+    /// live block positively matches *something*. Same abort-don't-guess
+    /// contract as the fully-unidentifiable case.
+    @Test func ambiguousLiveOwnerAcrossAccountsAbortsWithoutWritingAnyVaultBackup() async {
+        var state = makeState()
+        state.accounts[1].organizationUuid = "org-a" // now both accounts share "org-a"
+        var writeVaultBackupCalled = false
+
+        let switcher = NativeAccountSwitcher(
+            stateFile: URL(fileURLWithPath: "/dev/null"),
+            diagnosticLog: nil,
+            readVaultBackup: { _ in CredentialBackup(liveCredentials: Data("target".utf8), oauthAccountBlock: nil) },
+            writeVaultBackup: { _, _ in writeVaultBackupCalled = true; return true },
+            readLiveCredentials: { Data("current".utf8) },
+            writeLiveCredentials: { _ in true },
+            readLiveOauthBlock: { self.oauthBlock(organizationUuid: "org-a") },
+            writeLiveOauthBlock: { _ in true },
+            loadState: { _ in state },
+            saveState: { _, _ in true }
+        )
+
+        let result = await switcher.switchTo(account: account("native-1", state: state))
+
+        #expect(result == false)
+        #expect(writeVaultBackupCalled == false)
+    }
+
+    /// Diagnostic-log coverage for the abort path: the message must explain
+    /// *why* the switch refused, not just that it failed silently.
+    @Test func unidentifiableLiveOwnerWritesExplanatoryDiagnostic() async throws {
+        let state = makeState()
+        let logFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("native-switch-test-\(UUID().uuidString).log")
+        defer { try? FileManager.default.removeItem(at: logFile) }
+
+        let switcher = NativeAccountSwitcher(
+            stateFile: URL(fileURLWithPath: "/dev/null"),
+            diagnosticLog: logFile,
+            readVaultBackup: { _ in CredentialBackup(liveCredentials: Data("target".utf8), oauthAccountBlock: nil) },
+            writeVaultBackup: { _, _ in true },
+            readLiveCredentials: { Data("current".utf8) },
+            writeLiveCredentials: { _ in true },
+            readLiveOauthBlock: { self.oauthBlock(organizationUuid: "org-unknown") },
+            writeLiveOauthBlock: { _ in true },
+            loadState: { _ in state },
+            saveState: { _, _ in true }
+        )
+
+        let result = await switcher.switchTo(account: account("native-1", state: state))
+        #expect(result == false)
+
+        let logContents = try String(contentsOf: logFile, encoding: .utf8)
+        #expect(logContents.contains("could not verify") || logContents.contains("cannot verify") || logContents.contains("ambiguous") || logContents.contains("live owner") || logContents.contains("no tracked account"))
+    }
 }


### PR DESCRIPTION
## Summary

`NativeAccountSwitcher.switchTo` trusted `native-accounts.json`'s stored
`activeId` as the truth about which account owns the *live* Claude
credentials. That pointer never gets updated by the token-slayer backend
switch path, nor by a bare `token-slayer switch <name>` run directly in a
terminal, so it can silently diverge from reality. Trusting it caused two
bugs:

1. **Silent no-op** — switching to the account the stale pointer already
   claims is active returns success immediately without touching anything,
   even though the live credentials really belong to someone else.
2. **Vault backup corruption (data loss)** — the live credentials being
   displaced get backed up under the *stale* `activeId`, silently
   overwriting a different account's stored refresh token. That account is
   then unrecoverable without a fresh `claude /login`.

## Fix

Before the early-return guard, read the live `oauthAccount` block and match
it against the tracked accounts (`organizationUuid` first, falling back to
`email` — same priority `AccountCapture.matchingIndex` already uses) to
derive who actually owns the live credentials. Use that derived owner —
not the stored pointer — for both the no-op guard and the outgoing vault
backup destination.

- **Live owner identified, differs from stored `activeId`** → treat it as
  the real outgoing account for both the guard and the backup write.
  Persisting the corrected `activeId` falls out naturally at the end of a
  successful switch.
- **Live owner identified, matches stored `activeId`** → unchanged
  behavior (now confirmed rather than assumed).
- **Live block unreadable or carries neither `organizationUuid` nor
  `email`** → not enough information to contradict the stored pointer, so
  fall back to trusting it exactly as before (this is what keeps every
  pre-existing test — which use opaque placeholder byte blobs for the
  oauth block — passing unmodified).
- **Live block positively matches zero tracked accounts, or matches more
  than one (ambiguous — e.g. a corrupted `native-accounts.json` with a
  duplicate `organizationUuid`)** → abort, return `false`, write a
  diagnostic explaining why. No vault write happens. Guessing here is
  exactly the corruption this fix removes, so refusing is the safer
  outcome.

Everything the derivation touches goes through the already-injected
`readLiveOauthBlock` closure — no new non-injected I/O.

## Judgement calls

- **Matching key**: `organizationUuid` first, `email` fallback, mirroring
  the existing precedent in `AccountCapture.matchingIndex`.
- **Ambiguous case**: defined as the chosen key matching more than one
  tracked account (e.g. two accounts sharing an `organizationUuid` due to
  data corruption), not just "key present but nothing found" — both map to
  `.unidentifiable` and abort.
- **"Not enough information" vs. "unidentifiable"**: a live block that's
  `nil`, unparsable, or has neither `organizationUuid` nor `email` is
  treated as *inconclusive* (falls back to the stored pointer) rather than
  *unidentifiable* (aborts). This was necessary to keep the existing test
  suite's opaque placeholder oauth-block bytes (e.g. `Data("current-oauth"
  .utf8)`) behaving exactly as before, and reflects that the real-world
  ~/.claude.json block should always carry at least an email once any
  login has happened — a block with genuinely neither field is far more
  likely a transient/unreadable-file case than a deliberate "no owner"
  signal.

## Test plan

- [x] TDD: wrote 7 new failing tests first (`swift test --filter
      NativeAccountSwitcherTests`), confirmed they failed for the right
      reason (stale pointer trusted, no derivation logic), then
      implemented the fix and watched them go green.
- [x] `make test` — full suite, 366 tests passed (359 pre-existing + 7
      new), 0 failures.
- [x] Verified only `NativeAccountSwitcher.swift` and its test file
      changed — no version bump, no README/docs touched, no token-slayer
      code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
