### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/Sources/StatusBarCore/StatusBarCore.swift
+++ b/Sources/StatusBarCore/StatusBarCore.swift
@@ -1,3 +1,3 @@
 public enum StatusBarCoreInfo {
-    public static let version = "0.1.11"
+    public static let version = "1.0.0"
 }

--- a/Tests/StatusBarCoreTests/PackageTests.swift
+++ b/Tests/StatusBarCoreTests/PackageTests.swift
@@ -2,5 +2,5 @@ import Testing
 @testable import StatusBarCore
 
 @Test func versionIsSet() {
-    #expect(StatusBarCoreInfo.version == "0.1.11")
+    #expect(StatusBarCoreInfo.version == "1.0.0")
 }

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-VERSION="${VERSION:-0.1.11}"
+VERSION="${VERSION:-1.0.0}"
 APP="dist/ClaudeStatusBar.app"
 BIN=".build/release"
 


### PR DESCRIPTION
Version-bump PR for the 1.0.0 release, following the established pattern: bump, merge, tag, publish.

Bumps `0.1.11` → `1.0.0` in the three places the version lives:

- `Sources/StatusBarCore/StatusBarCore.swift` — `StatusBarCoreInfo.version`, the single source of truth
- `Tests/StatusBarCoreTests/PackageTests.swift` — the assertion that pins it
- `scripts/make-app.sh` — `VERSION` default, stamped into the app bundle's `Info.plist`

No functional changes.

## What 1.0.0 contains (since v0.1.11)

- **#43** — prune stale session files
- **#44** — refresh usage on popover open and on wake, cutting poll latency
- **#45** — token-slayer backend: accounts, usage, switching, add-account and re-login delegated to the `token-slayer` CLI when it is installed (`useTokenSlayer`, on by default, opt-out in Settings)
- **#46** — fix the recurring Keychain re-prompt on session reopen; interactive reads are now restricted to a failed non-interactive probe with an unspent once-per-launch gate, or an explicitly user-initiated action
- **#47** — fix a stale `native-accounts.json` pointer that could silently no-op a switch and write one account's live credentials into another's vault backup

## Verification

`make test` → `Test run with 366 tests passed`.
