### PR TITLE
Hide token-slayer toggle in Settings when the CLI isn't installed

### DIFF
--- a/Sources/ClaudeStatusBar/AppState.swift
+++ b/Sources/ClaudeStatusBar/AppState.swift
@@ -41,6 +41,15 @@ final class AppState {
     /// isn't installed). Drives the UI's subtle backend indicator.
     private(set) var slayerBinaryPath: String?
     var usingSlayerBackend: Bool { slayerBinaryPath != nil }
+    /// Whether the token-slayer CLI is installed on this machine, resolved
+    /// once at launch independently of `settings.useTokenSlayer`. Drives
+    /// whether the Settings toggle is offered at all — a toggle for a backend
+    /// that isn't installed is just a dead control. Like every other
+    /// token-slayer path, resolution is cached for the process lifetime
+    /// (TokenSlayerCLI.resolveBinary), so installing the CLI mid-session
+    /// needs a relaunch to be picked up — the same tradeoff the rest of the
+    /// slayer integration already makes.
+    private(set) var tokenSlayerInstalled = false
     /// Message from the most recent failed slayer `list`/`status` read —
     /// surfaced as a small footer in Settings; nil once a call succeeds. A
     /// `sessions` failure does *not* set this: it only backs the secondary
@@ -128,6 +137,18 @@ final class AppState {
         started = true
         try? paths.ensureDirs()
         usageStore.loadCache()
+        // Resolved once here, unconditionally — regardless of whether
+        // `settings.useTokenSlayer` is on — so the Settings toggle knows
+        // whether to offer itself at all even while the setting is off (see
+        // `tokenSlayerInstalled`'s doc comment). Backgrounded like
+        // `selfHealTask` below since `resolveBinary()` may shell out and
+        // start() itself must stay synchronous; `TokenSlayerCLI.resolveBinary`
+        // caches for the actor's lifetime, so this is reused rather than
+        // duplicated by the later `resolveSlayerBinaryIfEnabled()` calls.
+        Task { [weak self] in
+            guard let self else { return }
+            self.tokenSlayerInstalled = await self.tokenSlayerCLI.resolveBinary() != nil
+        }
         // Native discovery is skipped up front when the setting says slayer
         // mode will own this session — avoids both an unnecessary native
         // Keychain-adjacent read and the cosmetic flash of native accounts

--- a/Sources/ClaudeStatusBar/SettingsView.swift
+++ b/Sources/ClaudeStatusBar/SettingsView.swift
@@ -143,9 +143,11 @@ private struct AccountsTab: View {
 
     var body: some View {
         Form {
-            Toggle("Use token-slayer backend (when installed)", isOn: $settings.useTokenSlayer)
-            Text(backendStatusText)
-                .font(.caption).foregroundStyle(.secondary)
+            if appState.tokenSlayerInstalled {
+                Toggle("Use token-slayer backend", isOn: $settings.useTokenSlayer)
+                Text(backendStatusText)
+                    .font(.caption).foregroundStyle(.secondary)
+            }
             if let slayerErrorMessage = appState.slayerErrorMessage {
                 Text(slayerErrorMessage).font(.caption).foregroundStyle(.orange)
             }


### PR DESCRIPTION
## What

Hide the "Use token-slayer backend" Settings toggle when the `token-slayer`
CLI is not installed on the machine. When it IS installed, behavior is
unchanged.

## Why the existing signal can't be reused

`AppState` already tracks `slayerBinaryPath` / `usingSlayerBackend`, but
those can't gate the toggle: `resolveSlayerBinaryIfEnabled()` short-circuits
to `slayerBinaryPath = nil` whenever `settings.useTokenSlayer` is off,
*without* ever probing for the binary. That conflates "setting off" with
"CLI not installed" — gating the toggle on it would make the toggle vanish
the instant a user turns it off, with no way to ever turn it back on.

So this adds a separate, setting-independent signal:
`AppState.tokenSlayerInstalled`, resolved once in `start()` via
`tokenSlayerCLI.resolveBinary()` regardless of whether the setting is on.
`SettingsView`'s `AccountsTab` wraps the Toggle and its status caption in
`if appState.tokenSlayerInstalled { ... }`; the error message, "No Claude
account found" text, and account list stay unconditional.

## Tradeoff

`TokenSlayerCLI.resolveBinary()` caches for the actor's process lifetime,
so the launch-time call this PR adds is reused (not duplicated) by every
existing `resolveSlayerBinaryIfEnabled()` call site — no extra filesystem
probe. The flip side: installing `token-slayer` mid-session won't make the
toggle appear until the app relaunches. That matches every other
launch-cached resolution already in the slayer integration, so it's not a
new tradeoff, just the same one applied to this signal.

## Diff scope

Only `Sources/ClaudeStatusBar/AppState.swift` and
`Sources/ClaudeStatusBar/SettingsView.swift`. Also dropped the now-redundant
"(when installed)" suffix from the toggle's label, since the toggle only
ever renders when it is installed.

## Verification

- `make build` — clean (only pre-existing `kSecUseAuthenticationUIAllow`
  deprecation warnings).
- `make test` — `Test run with 366 tests passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
