### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/Sources/StatusBarCore/StatusBarCore.swift
+++ b/Sources/StatusBarCore/StatusBarCore.swift
@@ -1,3 +1,3 @@
 public enum StatusBarCoreInfo {
-    public static let version = "1.0.0"
+    public static let version = "1.0.1"
 }

--- a/Tests/StatusBarCoreTests/PackageTests.swift
+++ b/Tests/StatusBarCoreTests/PackageTests.swift
@@ -2,5 +2,5 @@ import Testing
 @testable import StatusBarCore
 
 @Test func versionIsSet() {
-    #expect(StatusBarCoreInfo.version == "1.0.0")
+    #expect(StatusBarCoreInfo.version == "1.0.1")
 }

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-VERSION="${VERSION:-1.0.0}"
+VERSION="${VERSION:-1.0.1}"
 APP="dist/ClaudeStatusBar.app"
 BIN=".build/release"
 


### PR DESCRIPTION
Version-bump PR for the 1.0.1 release, following the established pattern: bump, merge, tag, publish.

Bumps `1.0.0` → `1.0.1` in the three places the version lives:

- `Sources/StatusBarCore/StatusBarCore.swift` — `StatusBarCoreInfo.version`, the single source of truth
- `Tests/StatusBarCoreTests/PackageTests.swift` — the assertion that pins it
- `scripts/make-app.sh` — `VERSION` default, stamped into the app bundle's `Info.plist`

No functional changes.

## What 1.0.1 contains (since v1.0.0)

- **#49** — hide the Settings "Use token-slayer backend" toggle when the `token-slayer` CLI isn't installed, so the control only appears when it can actually do something

## Verification

`make test` → `Test run with 366 tests passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
